### PR TITLE
Nova estrutura

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ widdershins:
 	mkdir -p ${OUT_DIR}
 
 	widdershins ${SWAGGER_DIR}/metrics.yaml              -o ${OUT_DIR}/_metrics.md.erb            ${WIDDERSHINS_OPTS}
-	#widdershins ${SWAGGER_DIR}/status_outage.yaml        -o ${OUT_DIR}/_status_outage.md.erb      ${WIDDERSHINS_OPTS}
+	widdershins ${SWAGGER_DIR}/status_outage.yaml        -o ${OUT_DIR}/_status_outage.md.erb      ${WIDDERSHINS_OPTS}
 	widdershins ${SWAGGER_DIR}/canais_atendimento.yaml   -o ${OUT_DIR}/_canais_atendimento.md.erb ${WIDDERSHINS_OPTS}
 	widdershins ${SWAGGER_DIR}/auto-insurance.yaml       -o ${OUT_DIR}/_auto.md.erb               ${WIDDERSHINS_OPTS}
 	widdershins ${SWAGGER_DIR}/capitalization-title.yaml -o ${OUT_DIR}/_capitalization.md.erb     ${WIDDERSHINS_OPTS}
@@ -18,7 +18,7 @@ widdershins:
 
 validate:
 	swagger-cli validate ${SWAGGER_DIR}/metrics.yaml
-	#swagger-cli validate ${SWAGGER_DIR}/status_outage.yaml
+	swagger-cli validate ${SWAGGER_DIR}/status_outage.yaml
 	swagger-cli validate ${SWAGGER_DIR}/canais_atendimento.yaml
 
 	swagger-cli validate ${SWAGGER_DIR}/auto-insurance.yaml
@@ -28,8 +28,9 @@ validate:
 	swagger-cli validate ${SWAGGER_DIR}/pension-plan.yaml
 	swagger-cli validate ${SWAGGER_DIR}/person.yaml
 
+lint:
 	spectral lint ${SWAGGER_DIR}/metrics.yaml
-	#spectral lint ${SWAGGER_DIR}/status_outage.yaml
+	spectral lint ${SWAGGER_DIR}/status_outage.yaml
 	spectral lint ${SWAGGER_DIR}/canais_atendimento.yaml
 
 	spectral lint ${SWAGGER_DIR}/auto-insurance.yaml

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,40 @@
+
+SWAGGER_DIR := documentation/source/files/swagger
+OUT_DIR := documentation/source/includes/partials
+WIDDERSHINS_OPTS := --language_tabs "javascript:JavaScript:request" "python:Python:request" "java:Java::request" --omitHeader --summary --httpsnippet
+
 widdershins:
-	cd documentation && mkdir -p source/includes/partials_admin_metrics
-	cd documentation && mkdir -p source/includes/partials_common_apis
-	cd documentation && mkdir -p source/includes/partials_open_insurance
-	cd documentation && widdershins source/swagger/admin_metrics.yaml -o source/includes/partials_admin_metrics/_admin_metrics.md.erb --language_tabs "javascript:JavaScript:request" "python:Python:request" "java:Java::request" --omitHeader --summary --httpsnippet
-	cd documentation && widdershins source/swagger/status_outage.yaml -o source/includes/partials_common_apis/_status_outage.md.erb --language_tabs "javascript:JavaScript:request" "python:Python:request" "java:Java::request" --omitHeader --summary --httpsnippet
-	cd documentation && widdershins source/swagger/open_data_channels.yaml -o source/includes/partials_open_insurance/_open_data_channels.md.erb --language_tabs "javascript:JavaScript:request" "python:Python:request" "java:Java::request" --omitHeader --summary --httpsnippet
-	cd documentation && widdershins source/swagger/open_data_products_services.yaml -o source/includes/partials_open_insurance/_open_data_products_services.md.erb --language_tabs "javascript:JavaScript:request" "python:Python:request" "java:Java::request" --omitHeader --summary --httpsnippet
+	mkdir -p ${OUT_DIR}
+
+	widdershins ${SWAGGER_DIR}/metrics.yaml              -o ${OUT_DIR}/_metrics.md.erb            ${WIDDERSHINS_OPTS}
+	#widdershins ${SWAGGER_DIR}/status_outage.yaml        -o ${OUT_DIR}/_status_outage.md.erb      ${WIDDERSHINS_OPTS}
+	widdershins ${SWAGGER_DIR}/canais_atendimento.yaml   -o ${OUT_DIR}/_canais_atendimento.md.erb ${WIDDERSHINS_OPTS}
+	widdershins ${SWAGGER_DIR}/auto-insurance.yaml       -o ${OUT_DIR}/_auto.md.erb               ${WIDDERSHINS_OPTS}
+	widdershins ${SWAGGER_DIR}/capitalization-title.yaml -o ${OUT_DIR}/_capitalization.md.erb     ${WIDDERSHINS_OPTS}
+	widdershins ${SWAGGER_DIR}/home-insurance.yaml       -o ${OUT_DIR}/_home.md.erb               ${WIDDERSHINS_OPTS}
+	widdershins ${SWAGGER_DIR}/life-pension.yaml         -o ${OUT_DIR}/_life.md.erb               ${WIDDERSHINS_OPTS}
+	widdershins ${SWAGGER_DIR}/pension-plan.yaml         -o ${OUT_DIR}/_pension.md.erb            ${WIDDERSHINS_OPTS}
+	widdershins ${SWAGGER_DIR}/person.yaml               -o ${OUT_DIR}/_person.md.erb             ${WIDDERSHINS_OPTS}
 
 validate:
-	swagger-cli validate documentation/source/swagger/admin_metrics.yaml
-	swagger-cli validate documentation/source/swagger/status_outage.yaml
-	swagger-cli validate documentation/source/swagger/open_data_channels.yaml
-	swagger-cli validate documentation/source/swagger/open_data_products_services.yaml
+	swagger-cli validate ${SWAGGER_DIR}/metrics.yaml
+	#swagger-cli validate ${SWAGGER_DIR}/status_outage.yaml
+	swagger-cli validate ${SWAGGER_DIR}/canais_atendimento.yaml
 
-	spectral lint documentation/source/swagger/admin_metrics.yaml
-	spectral lint documentation/source/swagger/status_outage.yaml
-	spectral lint documentation/source/swagger/open_data_channels.yaml
-	spectral lint documentation/source/swagger/open_data_products_services.yaml
+	swagger-cli validate ${SWAGGER_DIR}/auto-insurance.yaml
+	swagger-cli validate ${SWAGGER_DIR}/capitalization-title.yaml
+	swagger-cli validate ${SWAGGER_DIR}/home-insurance.yaml
+	swagger-cli validate ${SWAGGER_DIR}/life-pension.yaml
+	swagger-cli validate ${SWAGGER_DIR}/pension-plan.yaml
+	swagger-cli validate ${SWAGGER_DIR}/person.yaml
+
+	spectral lint ${SWAGGER_DIR}/metrics.yaml
+	#spectral lint ${SWAGGER_DIR}/status_outage.yaml
+	spectral lint ${SWAGGER_DIR}/canais_atendimento.yaml
+
+	spectral lint ${SWAGGER_DIR}/auto-insurance.yaml
+	spectral lint ${SWAGGER_DIR}/capitalization-title.yaml
+	spectral lint ${SWAGGER_DIR}/home-insurance.yaml
+	spectral lint ${SWAGGER_DIR}/life-pension.yaml
+	spectral lint ${SWAGGER_DIR}/pension-plan.yaml
+	spectral lint ${SWAGGER_DIR}/person.yaml

--- a/documentation/source/files/swagger/auto-insurance.yaml
+++ b/documentation/source/files/swagger/auto-insurance.yaml
@@ -147,7 +147,7 @@ components:
             type: string
             description: Área de comercialização do seguro do automóvel.
             maxLength: 8
-            example: 1311000
+            example: '1311000'
           additional:
             type: array
             items:
@@ -176,7 +176,7 @@ components:
             description: Rede de atendimento do seguro contratado.
             items:
               type: string
-              example: REDE_REFERECIADA
+              example: REDE_REFERENCIADA
               enum: [ REDE_REFERENCIADA, LIVRE_ESCOLHA, REDE_REFERENCIADA_LIVRE_ESCOLHA ]
           premiumPayment:
             $ref: '#/components/schemas/AutoInsurancePremiumPayment'
@@ -267,7 +267,7 @@ components:
         contractBaseType:
           type: string
           description: Incidência ao capital segurado da cobertura de casco.
-          example: VALOR DETERMINADO
+          example: VALOR_DETERMINADO
           enum: [ VALOR_DETERMINADO, VALOR_MERCADO, AMBOS ]
         contractBaseMinValue:
           $ref: '#/components/schemas/AutoInsuranceCovaregeAttibutesDetails'

--- a/documentation/source/files/swagger/auto-insurance.yaml
+++ b/documentation/source/files/swagger/auto-insurance.yaml
@@ -1,20 +1,20 @@
 openapi: 3.0.0
 info:
   title: APIs Open Data do Open Insurance Brasil
-  description: 
+  description:
     API de informações de Seguro de Automóveis. Os recursos que podem ser consumidos pelos participantes conforme a regra 3.2.2 do manual de escopo de dados.
   version: 1.0.0
   contact:
-    url: 'https://http://novosite.susep.gov.br'
+    url: 'https://novosite.susep.gov.br'
 servers:
   - url: 'https://api.organizacao.com.br/open-insurance/products-services/v1'
     description: Servidor de Produção
   - url: 'https://api.organizacao.com.br/open-insurance/products-services/v1'
-    description: Servidor de Homologação  
+    description: Servidor de Homologação
 tags:
-- name: "auto-insurance"
+  - name: "auto-insurance"
 paths:
-  /auto-insurance/{commercializationArea}/{fipeCode}/{year}:  
+  /auto-insurance/{commercializationArea}/{fipeCode}/{year}:
     get:
       tags:
         - auto-insurance
@@ -57,7 +57,11 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
         default:
-          $ref: '#/components/schemas/ResponseAutoInsuranceList'               
+          description: Resposta
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseAutoInsuranceList'
 components:
   schemas:
     ResponseAutoInsuranceList:
@@ -70,7 +74,7 @@ components:
         data:
           type: object
           required:
-            - AutoInsuranceBrand
+            - brand
           properties:
             brand:
               $ref: '#/components/schemas/AutoInsuranceBrand'
@@ -88,7 +92,7 @@ components:
           type: string
           description: Nome da marca reportada pelo participante do Open Insurance. O conceito a que se refere a marca é em essência uma promessa das sociedades sob ela em fornecer uma série específica de atributos, benefícios e serviços uniformes aos clientes.
         company:
-          $ref: '#/components/schemas/AutoInsuranceCompany'  
+          $ref: '#/components/schemas/AutoInsuranceCompany'
     AutoInsuranceCompany:
       type: array
       items:
@@ -104,9 +108,9 @@ components:
           cnpjNumber:
             type: string
             description: CNPJ da sociedade pertencente à marca.
-          products:  
-            type: object
-            description: Lista de Dependências de uma Instituição.
+          products:
+            #type: object
+            #description: Lista de Dependências de uma Instituição.
             $ref: '#/components/schemas/AutoInsuranceProduct'
     AutoInsuranceProduct:
       type: array
@@ -136,10 +140,10 @@ components:
             type: string
             description: Código único a ser definido pela sociedade.
           coverages:
-            $ref: '#/components/schemas/AutoInsuranceCoverage'        
-          carParts:        
+            $ref: '#/components/schemas/AutoInsuranceCoverage'
+          carParts:
             $ref: '#/components/schemas/AutoInsuranceCarPart'
-          carModels:         
+          carModels:
             $ref: '#/components/schemas/AutoInsuranceCarModel'
           vehicleOvernightZipCode:
             type: string
@@ -152,154 +156,147 @@ components:
               type: string
               description: Adicionais
               example: SORTEIO GRATUITO
-              enum: [SORTEIO_GRATUITO , CLUBE_BENEFICIOS , CASHBACK, DESCONTOS, OUTROS]
+              enum: [ SORTEIO_GRATUITO, CLUBE_BENEFICIOS, CASHBACK, DESCONTOS, OUTROS ]
           additionalOthers:
             type: string
             description: Campo aberto para descrição de cada participante ao selecionar o domínio ‘Outros’ no campo acima ‘Adicionais’
           assistanceServices:
             type: array
             items:
-              $ref: '#/components/schemas/AutoInsuranceAssistanceServices'   
+              $ref: '#/components/schemas/AutoInsuranceAssistanceServices'
           termsAndConditions:
             $ref: '#/components/schemas/AutoInsuranceTermsAndConditions'
           terms:
-            type: array 
+            type: array
             description: Prazo.
             items:
-                type: string
-                example: ANUAL
-                enum: [ANUAL , ANUAL_INTERMITENTE , PLURIANUAL, PLURIANUAL_INTERMITENTE, SEMESTRAL, SEMESTRAL_INTERMITENTE, MENSAL, MENSAL_INTERMITENTE, DIARIO, DIARIO_INTERMITENTE, OUTROS]
+              type: string
+              example: ANUAL
+              enum: [ ANUAL, ANUAL_INTERMITENTE, PLURIANUAL, PLURIANUAL_INTERMITENTE, SEMESTRAL, SEMESTRAL_INTERMITENTE, MENSAL, MENSAL_INTERMITENTE, DIARIO, DIARIO_INTERMITENTE, OUTROS ]
           customerService:
-            type: array 
+            type: array
             description: Rede de atendimento do seguro contratado.
             items:
-                type: string
-                example: REDE REFERECIADA
-                enum: [REDE_REFERENCIADA , LIVRE_ESCOLHA , REDE_REFERENCIADA_LIVRE_ESCOLHA]  
+              type: string
+              example: REDE REFERECIADA
+              enum: [ REDE_REFERENCIADA, LIVRE_ESCOLHA, REDE_REFERENCIADA_LIVRE_ESCOLHA ]
           premiumPayment:
-            $ref: '#/components/schemas/AutoInsurancePremiumPayment'      
-          minimumRequirements: 
-            $ref: '#/components/schemas/AutoInsuranceMinimumRequirements'      
+            $ref: '#/components/schemas/AutoInsurancePremiumPayment'
+          minimumRequirements:
+            $ref: '#/components/schemas/AutoInsuranceMinimumRequirements'
           targetAudiences:
-            type: array 
+            type: array
             description: Público-alvo.
             items:
-                type: string         
-                maxLength: 30
-                example: PESSOA_NATURAL
-                enum: [PESSOA_NATURAL, PESSOA_JURIDICA, AMBAS] 
-    AutoInsuranceCoverage:     
+              type: string
+              maxLength: 30
+              example: PESSOA_NATURAL
+              enum: [ PESSOA_NATURAL, PESSOA_JURIDICA, AMBAS ]
+    AutoInsuranceCoverage:
       type: array
       description: Listagem de coberturas incluídas no produto que deve observar a relação discriminada de coberturas, conforme Tabela II.5 do Anexo II
       items:
         type: object
         required:
-        - coverage
-        - coverageDetail
-        - coverageAttribute
+          - coverage
+          - coverageDetail
+          - coverageAttributes
         properties:
-            coverage:
-              type: string
-              description: Conjunto de riscos elencados na apólice.
-              example: VIDROS
-              enum: [CASCO_COMPREENSIVA_COLISAO_INCENDIO_ROUBO_FURTO, 
-                      CASCO_INCENDIO_ROUBO_FURTO,
-                      CASCO_ROUBO_FURTO,
-                      CASCO_INCENDIO,
-                      CASCO_ALAGAMENTO, 
-                      CASCO_COLISAO_INDENIZACAO_PARCIAL, 
-                      CASCO_COLISAO_INDENIZACAO_INTEGRAL,
-                      RESPONSABILIDADE_CIVIL_FACULTATIVA_VEICULOS_RCFV, 
-                      RESPONSABILIDADE_CIVIL_FACULTATIVA_CONDUTOR_RCFC,
-                      ACIDENTE_PESSOAIS_PASSAGEIROS_VEICULO,
-                      ACIDENTE_PESSOAIS_PASSAGEIROS_CONDUTOR, 
-                      VIDROS,
-                      DIARIA_INDISPONIBILIDADE,
-                      LFR_LANTERNAS_FAROIS_RETROVISORES,
-                      ACESSORIOS_EQUIPAMENTOS,
-                      CARRO_RESERVA,
-                      PEQUENOS_REPAROS, 
-                      RESPONSABILIDADE_CIVIL_CARTA_VERDE,
-                      VOUCHER_MOBILIDADE,
-                      DESPESAS_EXTRAORDINARIAS,
-                      PEQUENOS_REPAROS,
-                      GARANTIA_MECANICA,
-                      OUTRAS]
-            coverageDetail:
-              type: string
-              description: Campo aberto para detalhamento de riscos possíveis dos produtos a ser feito para cada participante.
-              maxLength: 1000
-              example: Roubo total
-            coveragePermissionSeparteAcquisition:
-              type: boolean
-              description: Indicação se a cobertura permite contratação separada (por cobertura selecionada).
-              example: true
-            coverageAttributes:
-              $ref: '#/components/schemas/AutoInsuranceCoverageAttributes'         
+          coverage:
+            type: string
+            description: Conjunto de riscos elencados na apólice.
+            example: VIDROS
+            enum: [ CASCO_COMPREENSIVA_COLISAO_INCENDIO_ROUBO_FURTO,
+                    CASCO_INCENDIO_ROUBO_FURTO,
+                    CASCO_ROUBO_FURTO,
+                    CASCO_INCENDIO,
+                    CASCO_ALAGAMENTO,
+                    CASCO_COLISAO_INDENIZACAO_PARCIAL,
+                    CASCO_COLISAO_INDENIZACAO_INTEGRAL,
+                    RESPONSABILIDADE_CIVIL_FACULTATIVA_VEICULOS_RCFV,
+                    RESPONSABILIDADE_CIVIL_FACULTATIVA_CONDUTOR_RCFC,
+                    ACIDENTE_PESSOAIS_PASSAGEIROS_VEICULO,
+                    ACIDENTE_PESSOAIS_PASSAGEIROS_CONDUTOR,
+                    VIDROS,
+                    DIARIA_INDISPONIBILIDADE,
+                    LFR_LANTERNAS_FAROIS_RETROVISORES,
+                    ACESSORIOS_EQUIPAMENTOS,
+                    CARRO_RESERVA,
+                    PEQUENOS_REPAROS,
+                    RESPONSABILIDADE_CIVIL_CARTA_VERDE,
+                    VOUCHER_MOBILIDADE,
+                    DESPESAS_EXTRAORDINARIAS,
+                    GARANTIA_MECANICA,
+                    OUTRAS ]
+          coverageDetail:
+            type: string
+            description: Campo aberto para detalhamento de riscos possíveis dos produtos a ser feito para cada participante.
+            maxLength: 1000
+            example: Roubo total
+          coveragePermissionSeparteAcquisition:
+            type: boolean
+            description: Indicação se a cobertura permite contratação separada (por cobertura selecionada).
+            example: true
+          coverageAttributes:
+            $ref: '#/components/schemas/AutoInsuranceCoverageAttributes'
     AutoInsuranceCovaregeAttibutesDetailsUnit:
       type: object
       required:
         - code
         - description
       properties:
-        code: 
+        code:
           type: string
-        description: 
+        description:
           type: string
     AutoInsuranceCovaregeAttibutesDetails:
-        type: object
-        required:
-          - amount
-          - unit
-        properties:
-          amount:
-            type: number
-          unit:
-            $ref: '#/components/schemas/AutoInsuranceCovaregeAttibutesDetailsUnit'
+      type: object
+      required:
+        - amount
+        - unit
+      properties:
+        amount:
+          type: number
+        unit:
+          $ref: '#/components/schemas/AutoInsuranceCovaregeAttibutesDetailsUnit'
     AutoInsuranceContractBase:
       type: array
       description: Base de contratação.
       items:
-        type: object
         required:
           - contractBaseType
-        properties:
-            contractBaseType:
-              type: string
-              description: Incidência ao capital segurado da cobertura de casco.
-              example: VALOR DETERMINADO
-              enum: [VALOR_DETERMINADO, VALOR_MERCADO, AMBOS]
-            contractBaseMinValue:
-              description: Valor Base de Contratação Mínimo.
-              $ref: '#/components/schemas/AutoInsuranceCovaregeAttibutesDetails'
-            contractBaseMaxValue:
-              description: Valor Base de Contratação Máximo.
-              $ref: '#/components/schemas/AutoInsuranceCovaregeAttibutesDetails'
+      properties:
+        contractBaseType:
+          type: string
+          description: Incidência ao capital segurado da cobertura de casco.
+          example: VALOR DETERMINADO
+          enum: [ VALOR_DETERMINADO, VALOR_MERCADO, AMBOS ]
+        contractBaseMinValue:
+          $ref: '#/components/schemas/AutoInsuranceCovaregeAttibutesDetails'
+        contractBaseMaxValue:
+          $ref: '#/components/schemas/AutoInsuranceCovaregeAttibutesDetails'
     AutoInsuranceCoverageAttributes:
       type: object
       description: Atributos da cobertura.
       required:
-       - minLMI
-       - maxLMI
-       - contractBase
-       - newCarMaximumCalculatingPeriod
-       - fullIndemnityPercentage
-       - deductibleType
-       - fullIndemnityDeductible
-       - deductiblePaymentByCoverage
-       - deductiblePercentage
-       - mandatoryParticipation
-       - geographicScopeCoverage
+        - minLMI
+        - maxLMI
+        - contractBase
+        - newCarMaximumCalculatingPeriod
+        - fullIndemnityPercentage
+        - deductibleType
+        - fullIndemnityDeductible
+        - deductiblePaymentByCoverage
+        - deductiblePercentage
+        - mandatoryParticipation
+        - geographicScopeCoverage
       properties:
         minLMI:
           $ref: '#/components/schemas/AutoInsuranceCovaregeAttibutesDetails'
-          description: Lista com valor mínimo de LMI aceito pela sociedade para cada cobertura.
         maxLMI:
           $ref: '#/components/schemas/AutoInsuranceCovaregeAttibutesDetails'
-          description: Lista com valor máximo de LMI aceito pela sociedade para cada cobertura.
         contractBase:
           $ref: '#/components/schemas/AutoInsuranceContractBase'
-          description: Veículo Zero Km Base de Contratação
         newCarMaximumCalculatingPeriod:
           type: integer
           description: Prazo máximo para apuração do valor a ser indenizado para veículo zero quilômetro. Em meses.
@@ -307,19 +304,15 @@ components:
           example: 12
         newCarContractBase:
           $ref: '#/components/schemas/AutoInsuranceContractBase'
-          description: Semelhante ao campo “Atributos cobertura - base de contratação” aplicada ao veículo Zero Km. 
         fullIndemnityPercentage:
           $ref: '#/components/schemas/AutoInsuranceCovaregeAttibutesDetails'
-          description: Percentual do Limite Máximo de Indenização para caracterização de indenização integral.
-          maxLength: 6
-          example: 10.20
         deductibleType:
           type: array
           description: Listagem de tipo de franquia para cada tipo de cobertura do produto.
           items:
             type: string
             example: NORMAL
-            enum: [NORMAL, REDUZIDA, ISENTA, MAJORADA, FLEXIVEL]
+            enum: [ NORMAL, REDUZIDA, ISENTA, MAJORADA, FLEXIVEL ]
         fullIndemnityDeductible:
           type: boolean
           description: Franquia para Indenização Integral.
@@ -329,19 +322,18 @@ components:
           description: Sinalização para cada cobertura se a seguradora exige pagamento de franquia.
         deductiblePercentage:
           $ref: '#/components/schemas/AutoInsuranceCovaregeAttibutesDetails'
-          description: Listagem percentual de franquia e/ou percentual de participação obrigatória do segurado estabelecida pela sociedade para cada tipo de cobertura de produto.
         mandatoryParticipation:
           type: string
           description: Participação Obrigatória do Segurado.
           maxLength: 300
-          example: Casco - RCF-V Danos 
+          example: Casco - RCF-V Danos
         geographicScopeCoverage:
           type: array
           description: Listagem de abrangência geográfica do produto para fins de cada cobertura.
           items:
             type: string
             example: NACIONAL
-            enum: [NACIONAL, REGIONAL, INTERNACIONAL, OUTROS_PAISES]
+            enum: [ NACIONAL, REGIONAL, INTERNACIONAL, OUTROS_PAISES ]
         geographicScopeCoverageOthers:
           type: string
           description: Âmbito geográficoda cobertura - Outros
@@ -358,7 +350,7 @@ components:
           items:
             type: string
             example: COLETIVO
-            enum: [COLETIVO , INDIVIDUAL, AMBAS]
+            enum: [ COLETIVO, INDIVIDUAL, AMBAS ]
         contractingMinRequirement:
           type: string
           description: Campo aberto contendo todos os requisitos mínimos para contratação (possibilidade de incluir URL).
@@ -372,7 +364,7 @@ components:
         required:
           - susepProcessNumber
           - definition
-        properties:  
+        properties:
           susepProcessNumber:
             type: string
             description: Número do processo SUSEP.
@@ -384,30 +376,30 @@ components:
             maxLength: 1024
             example: https://ey.exemplo/capitalizacao/tradicional/pdf/condicoes_gerais.pdf
     AutoInsurancePremiumPayment:
-      type: object 
+      type: object
       description: Informações de pagamento de prêmio.
       required:
         - paymentMethod
-        - paymentTypee
+        - paymentType
       properties:
         paymentMethod:
-            type: array
-            description: Meio de pagamento escolhido pelo segurado.
-            items:
-              type: string
-              example: CARTÃO DE CRÉDITO
-              enum: [CARTAO_CREDITO, CARTAO_DEBITO, DEBITO_CONTA_CORRENTE , DEBITO_CONTA_POUPANCA , BOLETO_BANCARIO , PIX, CONSIGINACAO_FOLHA_PAGAMENTO, PONTOS_PROGRAMA_BENEFICIO, OUTROS]
+          type: array
+          description: Meio de pagamento escolhido pelo segurado.
+          items:
+            type: string
+            example: CARTÃO DE CRÉDITO
+            enum: [ CARTAO_CREDITO, CARTAO_DEBITO, DEBITO_CONTA_CORRENTE, DEBITO_CONTA_POUPANCA, BOLETO_BANCARIO, PIX, CONSIGINACAO_FOLHA_PAGAMENTO, PONTOS_PROGRAMA_BENEFICIO, OUTROS ]
         paymentType:
-            type: array
-            description: Forma de pagamento.
-            items:
-              type: string
-              example: PARCELADO
-              enum: [A_VISTA , PARCELADO, AMBOS]
+          type: array
+          description: Forma de pagamento.
+          items:
+            type: string
+            example: PARCELADO
+            enum: [ A_VISTA, PARCELADO, AMBOS ]
         paymentDetail:
           type: string
           description: Campo aberto para detalhamento do campo ‘Outros’ por cada participante.
-    AutoInsuranceAssistanceServices:    
+    AutoInsuranceAssistanceServices:
       type: object
       description: Serviços de Assistência.
       required:
@@ -415,68 +407,68 @@ components:
         - assistanceServicesDetail
       properties:
         assistanceServicesPackage:
-            type: array
-            description: Pacotes de Assistência - Agrupamento.
-            items:
-                type: string
-                example: ATE_10_SERVICOS
-                enum: [ATE_10_SERVICOS, ATE_20_SERVICOS, ACIMA_20_SERVICOS, CUSTOMIZAVEL]
+          type: array
+          description: Pacotes de Assistência - Agrupamento.
+          items:
+            type: string
+            example: ATE_10_SERVICOS
+            enum: [ ATE_10_SERVICOS, ATE_20_SERVICOS, ACIMA_20_SERVICOS, CUSTOMIZAVEL ]
         assistanceServicesDetail:
-            type: string
-            description:  Serviços de assistência - Detalhamento.
-            maxLength: 1000
-            example: Perda Parcial - Colisão
+          type: string
+          description: Serviços de assistência - Detalhamento.
+          maxLength: 1000
+          example: Perda Parcial - Colisão
         chargeTypeSignaling:
-            type: string
-            description: Sinalização em campo exclusivo se o pacote de Assistência é gratuita ou contratada/paga.
-            example: GRATUITA
-            enum: [GRATUITA, PAGA]
-    AutoInsuranceCarPart:    
+          type: string
+          description: Sinalização em campo exclusivo se o pacote de Assistência é gratuita ou contratada/paga.
+          example: GRATUITA
+          enum: [ GRATUITA, PAGA ]
+    AutoInsuranceCarPart:
       type: array
       description: Tipo de peça utilizada para reparação.
       items:
         required:
-        - carPartCondition
-        - carPartType
+          - carPartCondition
+          - carPartType
         properties:
-            carPartCondition:
-                type: string
-                description: Nova ou usada
-                example: NOVAS
-                enum: [NOVAS, USADAS, AMBAS]
-            carPartType:
-                type: string
-                description: Originais e não originais
-                example: ORIGINAIS
-                enum: [ORIGINAIS, COMPATIVEIS, AMBAS]
-    AutoInsuranceCarModel:    
+          carPartCondition:
+            type: string
+            description: Nova ou usada
+            example: NOVAS
+            enum: [ NOVAS, USADAS, AMBAS ]
+          carPartType:
+            type: string
+            description: Originais e não originais
+            example: ORIGINAIS
+            enum: [ ORIGINAIS, COMPATIVEIS, AMBAS ]
+    AutoInsuranceCarModel:
       type: array
       description: Listagem de modelos / ano de veículos. Deve ser padronizada na proposta técnica submetida pela Estrutura Inicial de Governança para observância comum por todas as sociedades participantes.
       items:
         required:
-            - manufacturer
-            - model
-            - year
-            - fipeCode
+          - manufacturer
+          - model
+          - year
+          - fipeCode
         properties:
-            manufacturer:
-                type: string
-                description: Fabricante
-                maxLength: 20
-                example: FORD 
-            model:
-                type: string
-                description: Modelo
-                maxLength: 20
-                example: KA 
-            year:
-                type: integer
-                description: Ano de fabricação.
-                maxLength: 4
-                example: 2018
-            fipeCode:
-                type: string
-                description: Código FIPE do veículo.
+          manufacturer:
+            type: string
+            description: Fabricante
+            maxLength: 20
+            example: FORD
+          model:
+            type: string
+            description: Modelo
+            maxLength: 20
+            example: KA
+          year:
+            type: integer
+            description: Ano de fabricação.
+            maxLength: 4
+            example: 2018
+          fipeCode:
+            type: string
+            description: Código FIPE do veículo.
     Links:
       type: object
       properties:
@@ -548,13 +540,13 @@ components:
                 description: 'Data e hora da consulta, conforme especificação RFC-3339, formato UTC.'
                 type: string
                 pattern: '[\w\W\s]*'
-                maxLength: 2048  
+                maxLength: 2048
                 format: date-time
                 example: '2021-08-20T08:30:00Z'
             additionalProperties: false
         meta:
           $ref: '#/components/schemas/Meta'
-      additionalProperties: false    
+      additionalProperties: false
   parameters:
     page:
       name: page
@@ -571,7 +563,7 @@ components:
       schema:
         type: integer
         default: 10
-        minimum: 1  
+        minimum: 1
     fipeCode:
       name: fipeCode
       in: path
@@ -598,7 +590,7 @@ components:
       in: header
       description: Controle de cache para evitar que informações confidenciais sejam armazenadas em cache.
       required: true
-      schema: 
+      schema:
         type: string
         pattern: '[\w\W\s]*'
     content-Security-Policy:
@@ -621,16 +613,16 @@ components:
       description: Campo para exigir conexões por HTTPS e proteger contra certificados falsificados.
       schema:
         type: string
-        pattern:  '[\w\W\s]*'
+        pattern: '[\w\W\s]*'
     x-Content-Type-Options:
-      name: X-Content-Type-Options
+      name: x-Content-Type-Options
       in: header
       description: Campo para evitar que navegadores executem a detecção de MIME e interpretem respostas como HTML de forma inadequada.
       schema:
         type: string
         pattern: '[\w\W\s]*'
     x-Frame-Options:
-      name: X-Frame-Options
+      name: x-Frame-Options
       in: header
       description: Campo indica se o navegador deve ou não renderizar um frame.
       schema:
@@ -648,7 +640,7 @@ components:
           authorizationUrl: 'https://authserver.example/authorization'
           tokenUrl: 'https://authserver.example/token'
           scopes:
-            financings: Escopo necessário para acesso à API. O controle dos endpoints específicos é feito via permissions.    
+            financings: Escopo necessário para acesso à API. O controle dos endpoints específicos é feito via permissions.
   responses:
 
     BadRequest:

--- a/documentation/source/files/swagger/auto-insurance.yaml
+++ b/documentation/source/files/swagger/auto-insurance.yaml
@@ -12,27 +12,27 @@ servers:
   - url: 'https://api.organizacao.com.br/open-insurance/products-services/v1'
     description: Servidor de Homologação
 tags:
-  - name: "auto-insurance"
+  - name: 'auto-insurance'
 paths:
   /auto-insurance/{commercializationArea}/{fipeCode}/{year}:
     get:
       tags:
         - auto-insurance
       summary: Obtém informações de seguros de automóveis
-      description: "Obtém informações de seguros de automóveis"
-      operationId: "getAutoInsurance"
+      description: 'Obtém informações de seguros de automóveis'
+      operationId: 'getAutoInsurance'
       parameters:
-        - $ref: "#/components/parameters/cache-Control"
-        - $ref: "#/components/parameters/content-Security-Policy"
-        - $ref: "#/components/parameters/content-Type"
-        - $ref: "#/components/parameters/strict-Transport-Security"
-        - $ref: "#/components/parameters/x-Content-Type-Options"
-        - $ref: "#/components/parameters/x-Frame-Options"
-        - $ref: "#/components/parameters/page"
-        - $ref: "#/components/parameters/pageSize"
-        - $ref: "#/components/parameters/commercializationArea"
-        - $ref: "#/components/parameters/fipeCode"
-        - $ref: "#/components/parameters/year"
+        - $ref: '#/components/parameters/cache-Control'
+        - $ref: '#/components/parameters/content-Security-Policy'
+        - $ref: '#/components/parameters/content-Type'
+        - $ref: '#/components/parameters/strict-Transport-Security'
+        - $ref: '#/components/parameters/x-Content-Type-Options'
+        - $ref: '#/components/parameters/x-Frame-Options'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
+        - $ref: '#/components/parameters/commercializationArea'
+        - $ref: '#/components/parameters/fipeCode'
+        - $ref: '#/components/parameters/year'
       responses:
         '200':
           description: Dados dos Seguros de Automóveis
@@ -109,8 +109,6 @@ components:
             type: string
             description: CNPJ da sociedade pertencente à marca.
           products:
-            #type: object
-            #description: Lista de Dependências de uma Instituição.
             $ref: '#/components/schemas/AutoInsuranceProduct'
     AutoInsuranceProduct:
       type: array
@@ -155,7 +153,7 @@ components:
             items:
               type: string
               description: Adicionais
-              example: SORTEIO GRATUITO
+              example: SORTEIO_GRATUITO
               enum: [ SORTEIO_GRATUITO, CLUBE_BENEFICIOS, CASHBACK, DESCONTOS, OUTROS ]
           additionalOthers:
             type: string
@@ -178,7 +176,7 @@ components:
             description: Rede de atendimento do seguro contratado.
             items:
               type: string
-              example: REDE REFERECIADA
+              example: REDE_REFERECIADA
               enum: [ REDE_REFERENCIADA, LIVRE_ESCOLHA, REDE_REFERENCIADA_LIVRE_ESCOLHA ]
           premiumPayment:
             $ref: '#/components/schemas/AutoInsurancePremiumPayment'
@@ -387,7 +385,7 @@ components:
           description: Meio de pagamento escolhido pelo segurado.
           items:
             type: string
-            example: CARTÃO DE CRÉDITO
+            example: CARTAO_CREDITO
             enum: [ CARTAO_CREDITO, CARTAO_DEBITO, DEBITO_CONTA_CORRENTE, DEBITO_CONTA_POUPANCA, BOLETO_BANCARIO, PIX, CONSIGINACAO_FOLHA_PAGAMENTO, PONTOS_PROGRAMA_BENEFICIO, OUTROS ]
         paymentType:
           type: array

--- a/documentation/source/files/swagger/auto-insurance.yaml
+++ b/documentation/source/files/swagger/auto-insurance.yaml
@@ -26,8 +26,8 @@ paths:
         - $ref: '#/components/parameters/content-Security-Policy'
         - $ref: '#/components/parameters/content-Type'
         - $ref: '#/components/parameters/strict-Transport-Security'
-        - $ref: '#/components/parameters/x-Content-Type-Options'
-        - $ref: '#/components/parameters/x-Frame-Options'
+        - $ref: '#/components/parameters/xxx-Content-Type-Options'
+        - $ref: '#/components/parameters/xxx-Frame-Options'
         - $ref: '#/components/parameters/page'
         - $ref: '#/components/parameters/pageSize'
         - $ref: '#/components/parameters/commercializationArea'
@@ -612,15 +612,15 @@ components:
       schema:
         type: string
         pattern: '[\w\W\s]*'
-    x-Content-Type-Options:
-      name: x-Content-Type-Options
+    xxx-Content-Type-Options:
+      name: xxx-Content-Type-Options
       in: header
       description: Campo para evitar que navegadores executem a detecção de MIME e interpretem respostas como HTML de forma inadequada.
       schema:
         type: string
         pattern: '[\w\W\s]*'
-    x-Frame-Options:
-      name: x-Frame-Options
+    xxx-Frame-Options:
+      name: xxx-Frame-Options
       in: header
       description: Campo indica se o navegador deve ou não renderizar um frame.
       schema:

--- a/documentation/source/files/swagger/canais_atendimento.yaml
+++ b/documentation/source/files/swagger/canais_atendimento.yaml
@@ -333,7 +333,7 @@ components:
           type: string
           description: Código IBGE de Município. A Tabela de Códigos de Municípios do IBGE apresenta a lista dos municípios brasileiros associados a um código composto de 7 dígitos, sendo os dois primeiros referentes ao código da Unidade da Federação.
           maxLength: 7
-          example: 3550308
+          example: '3550308'
         countrySubDivision:
           type: string
           description: Enumeração referente a cada sigla da unidade da federação que identifica o estado ou o distrito federal, no qual o endereço está localizado. São consideradas apenas as siglas para os estados brasileiros.
@@ -343,7 +343,7 @@ components:
           type: string
           description: Código de Endereçamento Postal. Composto por um conjunto numérico de oito dígitos, o objetivo principal do CEP é orientar e acelerar o encaminhamento, o tratamento e a entrega de objetos postados nos Correios, por meio da sua atribuição a localidades, logradouros, unidades dos Correios, serviços, órgãos públicos, empresas e edifícios.
           maxLength: 8
-          example: 17500-001
+          example: '17500001'
         country:
           type: string
           description: Nome do país.
@@ -369,13 +369,13 @@ components:
           maxLength: 4
           pattern: ^\d{4}$|^NA$
           description: Código identificador da dependência
-          example: 0001
+          example: '0001'
         checkDigit:
           type: string
           maxLength: 1
           pattern: \w*\W*
           description: Dígito verificador do código da dependência
-          example: 9
+          example: '9'
         name:
           type: string
           maxLength: 100
@@ -556,7 +556,7 @@ components:
             - '18'
             - '19'
           description: Código dos Serviços efetivamente prestados pelo Canal de Atendimento
-          example: 'PORTABILIDADE'
+          example: '19'
       required:
         - code
         - name
@@ -628,7 +628,7 @@ components:
             - INFORMACOES_SOBRE_SERVICOS_ASSISTENCIAS
             - INFORMACOES_SOBRE_SORTEIOS
             - OUVIDORIA_RECEPCAO_SUGESTOES_ELOGIOS
-            - OUVIDORIA_SOLUCAO_EVENTUAIS_DIVERGENCIAS_SOBRE_CONTRATO_SEGURO_CAPITALIZAÇÃO_PREVIDÊNCIA_APOS_ESGOTADOS_CANAIS_REGULARES_ATENDIMENTO_AQUELAS_ORIUNDAS_ORGAOS_REGULADORES_OU_INTEGRANTES_SISTEMA_NACIONAL_DEFESA_CONSUMIDOR
+            - OUVIDORIA_SOLUCAO_EVENTUAIS_DIVERGENCIAS_SOBRE_CONTRATO_SEGURO_CAPITALIZACAO_PREVIDENCIA_APOS_ESGOTADOS_CANAIS_REGULARES_ATENDIMENTO_AQUELAS_ORIUNDAS_ORGAOS_REGULADORES_OU_INTEGRANTES_SISTEMA_NACIONAL_DEFESA_CONSUMIDOR
             - OUVIDORIA_TRATAMENTO_INSATISFACAO_CONSUMIDOR_RELACAO_ATENDIMENTO_RECEBIDO_CANAIS_REGULARES_ATENDIMENTO
             - OUVIDORIA_TRATAMENTO_RECLAMACOES_SOBRE_IRREGULARDADES_CONDUTA_COMPANHIA
             - PORTABILIDADE
@@ -637,7 +637,7 @@ components:
             - SEGUNDA_VIA_DOCUMENTOS_CONTRATUAIS
             - SUGESTOES_ELOGIOS
           description: 'Nome dos Serviços efetivamente prestados pelo Canal de Atendimento'
-          example: 'ABERTURA_CONTAS_DEPOSITOS_OU_PAGAMENTO_PRE_PAGA'
+          example: 'ALTERACACOES_FORMA_PAGAMENTO'
         code:
           type: string
           enum:
@@ -662,7 +662,7 @@ components:
             - '19'
 
           description: 'Código dos Serviços efetivamente prestados pelo Canal de Atendimento'
-          example: 'RECLAMACAO'
+          example: '01'
     BranchPhone:
       type: object
       properties:
@@ -678,13 +678,13 @@ components:
           maxLength: 4
           pattern: ^\d{1,4}$
           example: '55'
-          description: 'Número de DDI (Discagem Direta Internacional) para  telefone de acesso ao Canal - se houver. p.ex. '55''
+          description: 'Número de DDI (Discagem Direta Internacional) para  telefone de acesso ao Canal - se houver. p.ex. "55"'
         areaCode:
           type: string
           maxLength: 2
           pattern: ^\d{2}$
           example: '19'
-          description: 'Número de DDD (Discagem Direta à Distância) do telefone da dependência - se houver. p.ex. '19''
+          description: 'Número de DDD (Discagem Direta à Distância) do telefone da dependência - se houver. p.ex. "19"'
         number:
           type: string
           maxLength: 11
@@ -732,7 +732,7 @@ components:
                           areaCode: '14'
                           number: '997865532'
                     services:
-                      - name: 'ALTERACACOES_FORMA_PAGAMENTO'
+                      - name: 'ALTERACOES_FORMA_PAGAMENTO'
                         code: '01'
                       - name: 'AVISO_SINISTRO'
                         code: '02'
@@ -794,7 +794,7 @@ components:
           type: string
           pattern: '\w*\W*'
           maxLength: 80
-          description: 'Nome da Marca reportada pelo participante do Open Insurance. O conceito a que se refere a 'marca' utilizada está em definição pelos participantes.'
+          description: 'Nome da Marca reportada pelo participante do Open Insurance. O conceito a que se refere a "marca" utilizada está em definição pelos participantes.'
           example: 'Marca A'
         companies:
           type: array

--- a/documentation/source/files/swagger/canais_atendimento.yaml
+++ b/documentation/source/files/swagger/canais_atendimento.yaml
@@ -4,23 +4,23 @@ info:
   description: As APIs descritas neste documento são referentes as APIs da fase Open Data do Open Insurance Brasil.
   version: 1.0.0
   contact:
-    url: 'https://http://novosite.susep.gov.br'
+    url: 'https://novosite.susep.gov.br'
 tags:
-  - name: "Channels"
-    description: "Operações para listagem de canais de atendimentos"
+  - name: 'Channels'
+    description: 'Operações para listagem de canais de atendimentos'
 servers:
   - url: http://api.organizacao.com.br/open-insurance/channels/v1
 paths:
   /branches:
     get:
       tags:
-        - "Channels"
+        - 'Channels'
       summary: Obtém a listagem de dependências próprias da instituição.
-      description: "Método para obter a listagem de dependências próprias da instituição."
-      operationId: "getBranches"
+      description: 'Método para obter a listagem de dependências próprias da instituição.'
+      operationId: 'getBranches'
       parameters:
-        - $ref: "#/components/parameters/page"
-        - $ref: "#/components/parameters/pageSize"
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
       responses:
         '200':
           description: Lista de dependências próprias obtida com sucesso.
@@ -45,17 +45,21 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
         default:
-          $ref: '#/components/schemas/ResponseBranchesList'        
+          description: Dados de canais
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseBranchesList'
   /electronic-channels:
     get:
       tags:
-        - "Channels"
+        - 'Channels'
       summary: Obtém a listagem de canais eletrônicos de atendimento da instituição.
-      description: "Método para obter a listagem de canais eletrônicos de atendimento da instituição."
-      operationId: "getElectronicChannels"
+      description: 'Método para obter a listagem de canais eletrônicos de atendimento da instituição.'
+      operationId: 'getElectronicChannels'
       parameters:
-        - $ref: "#/components/parameters/page"
-        - $ref: "#/components/parameters/pageSize"
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
       responses:
         '200':
           description: Listagem de canais eletrônicos de atendimento obtida com sucesso.
@@ -80,17 +84,21 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
         default:
-          $ref: '#/components/schemas/ResponseElectronicChannelsList'     
+          description: Dados de canais
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseElectronicChannelsList'
   /phone-channels:
     get:
       tags:
-        - "Channels"
-      summary: "Obtém a listagem de canais telefônicos de atendimento da instituição."
-      description: "Método para obter a listagem de canais telefônicos de atendimento da instituição."
-      operationId: "getPhoneChannels"
+        - 'Channels'
+      summary: 'Obtém a listagem de canais telefônicos de atendimento da instituição.'
+      description: 'Método para obter a listagem de canais telefônicos de atendimento da instituição.'
+      operationId: 'getPhoneChannels'
       parameters:
-        - $ref: "#/components/parameters/page"
-        - $ref: "#/components/parameters/pageSize"
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
       responses:
         '200':
           description: Listagem de canais telefônicos de atendimento obtida com sucesso.
@@ -115,7 +123,11 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
         default:
-          $ref: '#/components/schemas/ResponsePhoneChannelsList'    
+          description: Dados de canais
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponsePhoneChannelsList'
 components:
   schemas:
     ResponseBranchesList:
@@ -207,13 +219,13 @@ components:
                       urls:
                         - 'https://empresa1.com/insurance'
                     services:
-                      - name: "SEGUROS"
-                        code: "SEGUROS"
+                      - name: 'SEGUROS'
+                        code: 'SEGUROS'
         links:
           self: 'https://api.organizacao.com.br/open-insurance/channels/v1/electronic-channels'
           first: 'https://api.organizacao.com.br/open-insurance/channels/v1/electronic-channels'
-          prev: "null"
-          next: "null"
+          prev: 'null'
+          next: 'null'
           last: 'https://api.organizacao.com.br/open-insurance/channels/v1/electronic-channels'
         meta:
           totalRecords: 1
@@ -227,7 +239,7 @@ components:
         name:
           type: string
           description: Nome da marca selecionada pela Organização proprietária da dependência (titular).
-          example: "Marca A"
+          example: 'Marca A'
           maxLength: 80
           pattern: \w*\W*
         companies:
@@ -246,7 +258,7 @@ components:
         name:
           type: string
           description: Nome da marca selecionada pela Organização proprietária da dependência (titular).
-          example: "Empresa da Marca A"
+          example: 'Empresa da Marca A'
           maxLength: 80
           pattern: \w*\W*
         cnpjNumber:
@@ -343,14 +355,14 @@ components:
           maxLength: 3
           example: BRA
         geographicCoordinates:
-          $ref: '#/components/schemas/BranchesGeographicCoordinates'       
+          $ref: '#/components/schemas/BranchesGeographicCoordinates'
     BranchIdentification:
       type: object
       properties:
         type:
           type: string
           description: Tipo de dependência.
-          enum: [POSTO_ATENDIMENTO, UNIDADE_ADMINISTRATIVA_DESMEMBRADA]
+          enum: [ POSTO_ATENDIMENTO, UNIDADE_ADMINISTRATIVA_DESMEMBRADA ]
           example: POSTO_ATENDIMENTO
         code:
           type: string
@@ -369,7 +381,7 @@ components:
           maxLength: 100
           pattern: \w*\W*
           description: Nome da dependência
-          example: Marília      
+          example: Marília
     BranchAvailability:
       type: object
       properties:
@@ -520,34 +532,34 @@ components:
             - SEGUNDA_VIA_DOCUMENTOS_CONTRATUAIS
             - SUGESTOES_ELOGIOS
           description: Nome dos Serviços efetivamente prestados pelo Canal de Atendimento
-          example: "ENDOSSO"
+          example: 'ENDOSSO'
         code:
           type: string
           enum:
-            - "01"
-            - "02"
-            - "03"
-            - "04"
-            - "05"
-            - "06"
-            - "07"
-            - "08"
-            - "09"
-            - "10"
-            - "11"
-            - "12"
-            - "13"
-            - "14"
-            - "15"
-            - "16"
-            - "17"
-            - "18"
-            - "19"
+            - '01'
+            - '02'
+            - '03'
+            - '04'
+            - '05'
+            - '06'
+            - '07'
+            - '08'
+            - '09'
+            - '10'
+            - '11'
+            - '12'
+            - '13'
+            - '14'
+            - '15'
+            - '16'
+            - '17'
+            - '18'
+            - '19'
           description: Código dos Serviços efetivamente prestados pelo Canal de Atendimento
-          example: "PORTABILIDADE"
+          example: 'PORTABILIDADE'
       required:
-      - code
-      - name
+        - code
+        - name
     ElectronicChannels:
       type: object
       required:
@@ -562,7 +574,7 @@ components:
             $ref: '#/components/schemas/ElectronicChannelsServices'
           minItems: 1
           maxItems: 20
-          description: "Traz a relação de serviços disponbilizados pelo Canal de Atendimento"
+          description: 'Traz a relação de serviços disponbilizados pelo Canal de Atendimento'
         availability:
           $ref: '#/components/schemas/EletronicChannelsAvailability'
     ElectronicChannelsIdentification:
@@ -580,12 +592,12 @@ components:
             - WHATSAPP
             - CONSUMIDOR
             - OUTROS
-          description: "Tipo de canal de atendimento eletrônico"
-          example: "CHAT"
+          description: 'Tipo de canal de atendimento eletrônico'
+          example: 'CHAT'
         accessType:
           type: string
           description: Tipo de acesso
-          enum: [EMAIL, INTERNET, APP, CHAT, WHATSAPP, CONSUMIDOR, OUTROS]
+          enum: [ EMAIL, INTERNET, APP, CHAT, WHATSAPP, CONSUMIDOR, OUTROS ]
         urls:
           type: array
           items:
@@ -624,33 +636,33 @@ components:
             - RESGATE
             - SEGUNDA_VIA_DOCUMENTOS_CONTRATUAIS
             - SUGESTOES_ELOGIOS
-          description: "Nome dos Serviços efetivamente prestados pelo Canal de Atendimento"
-          example: "ABERTURA_CONTAS_DEPOSITOS_OU_PAGAMENTO_PRE_PAGA"
+          description: 'Nome dos Serviços efetivamente prestados pelo Canal de Atendimento'
+          example: 'ABERTURA_CONTAS_DEPOSITOS_OU_PAGAMENTO_PRE_PAGA'
         code:
           type: string
           enum:
-            - "01"
-            - "02"
-            - "03"
-            - "04"
-            - "05"
-            - "06"
-            - "07"
-            - "08"
-            - "09"
-            - "10"
-            - "11"
-            - "12"
-            - "13"
-            - "14"
-            - "15"
-            - "16"
-            - "17"
-            - "18"
-            - "19"
+            - '01'
+            - '02'
+            - '03'
+            - '04'
+            - '05'
+            - '06'
+            - '07'
+            - '08'
+            - '09'
+            - '10'
+            - '11'
+            - '12'
+            - '13'
+            - '14'
+            - '15'
+            - '16'
+            - '17'
+            - '18'
+            - '19'
 
-          description: "Código dos Serviços efetivamente prestados pelo Canal de Atendimento"
-          example: "RECLAMACAO"
+          description: 'Código dos Serviços efetivamente prestados pelo Canal de Atendimento'
+          example: 'RECLAMACAO'
     BranchPhone:
       type: object
       properties:
@@ -659,26 +671,26 @@ components:
           enum:
             - FIXO
             - MOVEL
-          example: "FIXO"
-          description: "Identificação do Tipo de telefone da dependência. p.ex.FIXO, MOVEL."
+          example: 'FIXO'
+          description: 'Identificação do Tipo de telefone da dependência. p.ex.FIXO, MOVEL.'
         countryCallingCode:
           type: string
           maxLength: 4
           pattern: ^\d{1,4}$
-          example: "55"
-          description: "Número de DDI (Discagem Direta Internacional) para  telefone de acesso ao Canal - se houver. p.ex. '55'"
+          example: '55'
+          description: 'Número de DDI (Discagem Direta Internacional) para  telefone de acesso ao Canal - se houver. p.ex. '55''
         areaCode:
           type: string
           maxLength: 2
           pattern: ^\d{2}$
-          example: "19"
-          description: "Número de DDD (Discagem Direta à Distância) do telefone da dependência - se houver. p.ex. '19'"
+          example: '19'
+          description: 'Número de DDD (Discagem Direta à Distância) do telefone da dependência - se houver. p.ex. '19''
         number:
           type: string
           maxLength: 11
           pattern: '^([0-9]{8,11})$'
-          example: "35721199"
-          description: "Número de telefone da dependência - se houver"
+          example: '35721199'
+          description: 'Número de telefone da dependência - se houver'
     ####################
     ## Phone ElectronicChannels ##
     ####################
@@ -765,8 +777,8 @@ components:
         links:
           self: 'https://api.organizacao.com.br/open-insurance/channels/v1/phone-channels'
           first: 'https://api.organizacao.com.br/open-insurance/channels/v1/phone-channels'
-          prev: "null"
-          next: "null"
+          prev: 'null'
+          next: 'null'
           last: 'https://api.organizacao.com.br/open-insurance/channels/v1/phone-channels'
         meta:
           totalRecords: 1
@@ -782,8 +794,8 @@ components:
           type: string
           pattern: '\w*\W*'
           maxLength: 80
-          description: "Nome da Marca reportada pelo participante do Open Insurance. O conceito a que se refere a 'marca' utilizada está em definição pelos participantes."
-          example: "Marca A"
+          description: 'Nome da Marca reportada pelo participante do Open Insurance. O conceito a que se refere a 'marca' utilizada está em definição pelos participantes.'
+          example: 'Marca A'
         companies:
           type: array
           items:
@@ -802,8 +814,8 @@ components:
           type: string
           pattern: \w*\W*
           maxLength: 80
-          description: "Nome da Instituição, pertencente à organização, responsável pelo Canal Telefônico."
-          example: "Empresa da Marca A"
+          description: 'Nome da Instituição, pertencente à organização, responsável pelo Canal Telefônico.'
+          example: 'Empresa da Marca A'
         cnpjNumber:
           type: string
           minLength: 14
@@ -849,18 +861,18 @@ components:
             - CENTRAL_TELEFONICA
             - SAC
             - OUVIDORIA
-          description: "
+          description: '
             Tipo de canal telefônico de atendimento:
               \n* `CENTRAL_TELEFONICA`
               \n* `SAC`
-              \n* `OUVIDORIA`"
-          example: "OUVIDORIA"
+              \n* `OUVIDORIA`'
+          example: 'OUVIDORIA'
         phones:
           type: array
           items:
             $ref: '#/components/schemas/PhoneChannelsPhones'
           minItems: 1
-          description: "Lista de telefones do Canal de Atendimento"
+          description: 'Lista de telefones do Canal de Atendimento'
     #### PhoneChannelPhones ####
     PhoneChannelsPhones:
       type: object
@@ -873,20 +885,20 @@ components:
           type: string
           maxLength: 4
           pattern: ^\d{1,4}$|^NA$
-          example: "55"
-          description: "Número de DDI (Discagem Direta Internacional) para telefone de acesso ao Canal - se houver."
+          example: '55'
+          description: 'Número de DDI (Discagem Direta Internacional) para telefone de acesso ao Canal - se houver.'
         areaCode:
           type: string
           maxLength: 2
           pattern: ^\d{2}$|^NA$
-          example: "19"
-          description: "Número de DDD (Discagem Direta à Distância) para telefone de acesso ao Canal - se houver."
+          example: '19'
+          description: 'Número de DDD (Discagem Direta à Distância) para telefone de acesso ao Canal - se houver.'
         number:
           type: string
           maxLength: 13
           pattern: ^([0-9]{8,11})$|^NA$
-          example: "08007787788"
-          description: "Número de telefone de acesso ao canal."      
+          example: '08007787788'
+          description: 'Número de telefone de acesso ao canal.'
     #### PhoneChannelsServices ####
     PhoneChannelsServices:
       type: object
@@ -917,30 +929,30 @@ components:
             - SEGUNDA_VIA_DOCUMENTOS_CONTRATUAIS
             - SUGESTOES_ELOGIOS
           description: Nome dos Serviços efetivamente prestados pelo Canal de Atendimento
-          example: "AVISO_SINISTRO"
+          example: 'AVISO_SINISTRO'
         code:
           type: string
           enum:
-            - "01"
-            - "02"
-            - "03"
-            - "04"
-            - "05"
-            - "06"
-            - "07"
-            - "08"
-            - "09"
-            - "10"
-            - "11"
-            - "12"
-            - "13"
-            - "14"
-            - "15"
-            - "16"
-            - "17"
-            - "18"
-            - "19"
-          description: "Código dos Serviços efetivamente prestados pelo Canal de Atendimento"    
+            - '01'
+            - '02'
+            - '03'
+            - '04'
+            - '05'
+            - '06'
+            - '07'
+            - '08'
+            - '09'
+            - '10'
+            - '11'
+            - '12'
+            - '13'
+            - '14'
+            - '15'
+            - '16'
+            - '17'
+            - '18'
+            - '19'
+          description: 'Código dos Serviços efetivamente prestados pelo Canal de Atendimento'
     BranchesGeographicCoordinates:
       type: object
       description: Informação referente a geolocalização informada.
@@ -956,18 +968,18 @@ components:
           type: string
           pattern: ^-?\d{1,3}\.\d{1,8}$
           maxLength: 13
-          example: '-180.836519'  
+          example: '-180.836519'
     LinksPaginated:
       type: object
       properties:
         self:
           type: string
           description: URL da página atualmente requisitada
-          example: "https://api.organizacao.com.br/open-insurance/channels/v1/<resource>"
+          example: 'https://api.organizacao.com.br/open-insurance/channels/v1/<resource>'
         first:
           type: string
           description: URL da primeira página de registros
-          example: "https://api.organizacao.com.br/open-insurance/channels/v1/<resource>"
+          example: 'https://api.organizacao.com.br/open-insurance/channels/v1/<resource>'
         prev:
           type: string
           description: URL da página anterior de registros
@@ -977,7 +989,7 @@ components:
         last:
           type: string
           description: URL da última página de registros
-          example: "https://api.organizacao.com.br/open-insurance/channels/v1/<resource>"
+          example: 'https://api.organizacao.com.br/open-insurance/channels/v1/<resource>'
     MetaPaginated:
       type: object
       properties:
@@ -1028,13 +1040,13 @@ components:
                 description: 'Data e hora da consulta, conforme especificação RFC-3339, formato UTC.'
                 type: string
                 pattern: '[\w\W\s]*'
-                maxLength: 2048  
+                maxLength: 2048
                 format: date-time
                 example: '2021-08-20T08:30:00Z'
             additionalProperties: false
         meta:
           $ref: '#/components/schemas/MetaPaginated'
-      additionalProperties: false   
+      additionalProperties: false
   parameters:
     page:
       name: page
@@ -1100,4 +1112,4 @@ components:
       content:
         application/json; charset=utf-8:
           schema:
-            $ref: '#/components/schemas/ResponseError' 
+            $ref: '#/components/schemas/ResponseError'

--- a/documentation/source/files/swagger/capitalization-title.yaml
+++ b/documentation/source/files/swagger/capitalization-title.yaml
@@ -5,31 +5,31 @@ info:
     API de informações de Título de Capitaliazação.
   version: 1.0.0
   contact:
-    url: 'https://http://novosite.susep.gov.br'
+    url: 'https://novosite.susep.gov.br'
 servers:
   - url: 'https://api.organizacao.com.br/open-insurance/products-services/v1'
     description: Servidor de Produção
   - url: 'https://api.organizacao.com.br/open-insurance/products-services/v1'
     description: Servidor de Homologação
 tags:
-- name: "capitalization-title"
+  - name: 'capitalization-title'
 paths:
   /capitalization-title:
     get:
       tags:
         - capitalization-title
       summary: Obtém a lista dos produtos do tipo título de capitalização
-      description: "Obtém a lista dos produtos do tipo título de capitalização"
-      operationId: "capitalizationTitle"
+      description: 'Obtém a lista dos produtos do tipo título de capitalização'
+      operationId: 'capitalizationTitle'
       parameters:
-        - $ref: "#/components/parameters/cache-Control"
-        - $ref: "#/components/parameters/content-Security-Policy"
-        - $ref: "#/components/parameters/content-Type"
-        - $ref: "#/components/parameters/strict-Transport-Security"
-        - $ref: "#/components/parameters/x-Content-Type-Options"
-        - $ref: "#/components/parameters/x-Frame-Options"
-        - $ref: "#/components/parameters/page"
-        - $ref: "#/components/parameters/pageSize"
+        - $ref: '#/components/parameters/cache-Control'
+        - $ref: '#/components/parameters/content-Security-Policy'
+        - $ref: '#/components/parameters/content-Type'
+        - $ref: '#/components/parameters/strict-Transport-Security'
+        - $ref: '#/components/parameters/x-Content-Type-Options'
+        - $ref: '#/components/parameters/x-Frame-Options'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
       responses:
         '200':
           description: Dados dos produtos de Título de Capitalização
@@ -64,7 +64,7 @@ components:
     ResponseCapitalizationTitleList:
       type: object
       required:
-        - data
+        #- data
         - brand
         - links
         - meta
@@ -114,7 +114,7 @@ components:
             type: string
             description: CNPJ da sociedade pertencente à marca.
             maxLength: 14
-            example: "12345678901234"
+            example: '12345678901234'
           product:
             $ref: '#/components/schemas/CapitalizationTitleProduct'
     CapitalizationTitleProduct:
@@ -127,7 +127,7 @@ components:
           - code
           - modality
           - quotas
-          - coverages
+          #- coverages
           - costType
         properties:
           name:
@@ -144,14 +144,14 @@ components:
             type: array
             description: Modalidade.
             items:
-                type: string
-                enum: [TRADICIONAL, INSTRUMENTO_GARANTIA, COMPRA_PROGRAMADA, POPULAR, INCENTIVO, FILANTROPIA_PREMIAVEL]
+              type: string
+              enum: [ TRADICIONAL, INSTRUMENTO_GARANTIA, COMPRA_PROGRAMADA, POPULAR, INCENTIVO, FILANTROPIA_PREMIAVEL ]
           costType:
             type: array
             description: Forma de custeio
             items:
-                type: string
-                enum: [PAGAMENTO_UNICO, PAGAMENTO_MENSAL, PAGAMENTO_PERIODICO]
+              type: string
+              enum: [ PAGAMENTO_UNICO, PAGAMENTO_MENSAL, PAGAMENTO_PERIODICO ]
           termsAndConditions:
             $ref: '#/components/schemas/CapitalizationTitleTerms'
           quotas:
@@ -194,97 +194,97 @@ components:
           maxLength: 1024
           example: https://ey.exemplo/capitalizacao/tradicional/pdf/condicoes_gerais.pdf
     CapitalizationTitleQuotas:
-        type: object
-        description: Quotas
-        required:
-          - quota
-          - capitalizationQuota
-          - raffleQuota
-          - chargingQuota
-        properties:
-            quota:
-              type: integer
-              description: Número da parcela.
-              example: 10
-            capitalizationQuota:
-              type: array
-              description: Percentual da contribuição destinado à constituição de capital referente ao direito de resgate.
-              items:
-                type: number
-                maxLength: 9
-                example: 10.000000
-            raffleQuota:
-              type: array
-              description: Percentual da contribuição designado a custear os sorteios, se previstos no plano
-              items:
-                type: number
-                maxLength: 9
-                example: 10.000000
-            chargingQuota:
-              type: array
-              description: Percentual da contribuição destinado aos custos de despesas com corretagem, colocação e administração do título de capitalização, emissão, divulgação, lucro da sociedade de capitalização e eventuais despesas relavas ao custeio da contemplação obrigatória e da distribuição de bônus.
-              items:
-                type: number
-                maxLength: 9
-                example: 10.000000
+      type: object
+      description: Quotas
+      required:
+        - quota
+        - capitalizationQuota
+        - raffleQuota
+        - chargingQuota
+      properties:
+        quota:
+          type: integer
+          description: Número da parcela.
+          example: 10
+        capitalizationQuota:
+          type: array
+          description: Percentual da contribuição destinado à constituição de capital referente ao direito de resgate.
+          items:
+            type: number
+            maxLength: 9
+            example: 10.000000
+        raffleQuota:
+          type: array
+          description: Percentual da contribuição designado a custear os sorteios, se previstos no plano
+          items:
+            type: number
+            maxLength: 9
+            example: 10.000000
+        chargingQuota:
+          type: array
+          description: Percentual da contribuição destinado aos custos de despesas com corretagem, colocação e administração do título de capitalização, emissão, divulgação, lucro da sociedade de capitalização e eventuais despesas relavas ao custeio da contemplação obrigatória e da distribuição de bônus.
+          items:
+            type: number
+            maxLength: 9
+            example: 10.000000
     CapitalizationTitleValidity:
-        type: integer
-        description: Prazo de vigência do título de capitalização em meses.
-        maxLength: 3
-        example: 48
+      type: integer
+      description: Prazo de vigência do título de capitalização em meses.
+      maxLength: 3
+      example: 48
     CapitalizationTitleSerieSize:
-        type: integer
-        description: Os títulos de capitalização que prevejam sorteio devem ser estruturados em series, ou seja, em sequencias ou em grupos de títulos submetidos às mesmas condições e características, à exceção do valor do pagamento.
-        maxLength: 10
-        example: 5000000
+      type: integer
+      description: Os títulos de capitalização que prevejam sorteio devem ser estruturados em series, ou seja, em sequencias ou em grupos de títulos submetidos às mesmas condições e características, à exceção do valor do pagamento.
+      maxLength: 10
+      example: 5000000
     CapitalizationTitlePeriod:
-        description: Período de Capitalização
-        type: object
-        required:
-          - interestRate
-          - updateIndex
-          - contributionAmount
-          - earlyRedemption
-          - redemptionPercentageEndTerm
-          - gracePeriodRedemption
-        properties:
-          interestRate:
-            description: Taxa que remunera a parte da mensalidade destinada a formar o Capital, ou seja, a Provisão Matemática de Resgate, também chamada de saldo de capitalização. Em porcentagem ao mês (% a.m)
+      description: Período de Capitalização
+      type: object
+      required:
+        - interestRate
+        - updateIndex
+        - contributionAmount
+        - earlyRedemption
+        - redemptionPercentageEndTerm
+        - gracePeriodRedemption
+      properties:
+        interestRate:
+          description: Taxa que remunera a parte da mensalidade destinada a formar o Capital, ou seja, a Provisão Matemática de Resgate, também chamada de saldo de capitalização. Em porcentagem ao mês (% a.m)
+          type: number
+          maxLength: 7
+          example: 0.25123
+        updateIndex:
+          type: array
+          description: Índice utilizado na correção que remunera a provisão matemática para capitalização
+          items:
+            type: string
+            example: IPCA
+            enum: [ IPCA, IGPM, INPC, TR, INDICE_REMUNERACAO_DEPOSITOS_POUPANCA, OUTROS ]
+        others:
+          type: array
+          description: Preenchida pelas participantes quando houver ‘Outros’ no campo.
+          items:
+            type: string
+            example: Índice de atualização
+        contributionAmount:
+          $ref: '#/components/schemas/CapitalizationTitleContributionAmount'
+        earlyRedemption:
+          description: Possibilidade de o titular efetuar o resgate do capital constituído antes do fim do prazo de vigência do título, podendo ocorrer por solicitação expressa do titular ou por contemplação em sorteio com liquidação antecipada
+          type: array
+          items:
             type: number
-            maxLength: 7
-            example: 0.25123
-          updateIndex:
-            type: array
-            description: Índice utilizado na correção que remunera a provisão matemática para capitalização
-            items:
-                type: string
-                example: IPCA
-                enum: [IPCA, IGPM, INPC, TR, INDICE_REMUNERACAO_DEPOSITOS_POUPANCA, OUTROS]
-          others:
-            type: array
-            description: Preenchida pelas participantes quando houver ‘Outros’ no campo.
-            items:
-                type: string
-                example: Índice de atualização
-          contributionAmount:
-            $ref: '#/components/schemas/CapitalizationTitleContributionAmount'
-          earlyRedemption:
-            description: Possibilidade de o titular efetuar o resgate do capital constituído antes do fim do prazo de vigência do título, podendo ocorrer por solicitação expressa do titular ou por contemplação em sorteio com liquidação antecipada
-            type: array
-            items:
-                type: number
-                maxLength: 9
-                example: 10.000000
-          redemptionPercentageEndTerm:
-            description: Percentual mínimo da soma das contribuições efetuadas que poderá ser resgatado ao final da vigência,  tendo como condição os pagamentos das parcelas nos respectivos vencimentos.
-            type: number
-            maxLength: 7
-            example: 100.002
-          gracePeriodRedemption:
-            description: Intervalo de tempo mínimo entre contratação e resgate do direito, em meses.
-            type: integer
-            maxLength: 3
-            example: 48
+            maxLength: 9
+            example: 10.000000
+        redemptionPercentageEndTerm:
+          description: Percentual mínimo da soma das contribuições efetuadas que poderá ser resgatado ao final da vigência,  tendo como condição os pagamentos das parcelas nos respectivos vencimentos.
+          type: number
+          maxLength: 7
+          example: 100.002
+        gracePeriodRedemption:
+          description: Intervalo de tempo mínimo entre contratação e resgate do direito, em meses.
+          type: integer
+          maxLength: 3
+          example: 48
     CapitalizationTitleContributionAmount:
       type: object
       properties:
@@ -300,26 +300,26 @@ components:
           type: string
           description: Pagamento mensal, pagamento único ou periódico.
           example: MENSAL
-          enum: [MENSAL, UNICO, PERIODICO]
+          enum: [ MENSAL, UNICO, PERIODICO ]
         value:
           type: number
           description: valor
     CapitalizationTitleLatePayment:
-        type: object
-        description: Atraso de Pagamento
-        required:
+      type: object
+      description: Atraso de Pagamento
+      required:
         - suspensionPeriod
         - termExtensionOption
-        properties:
-          suspensionPeriod:
-            description: Prazo máximo (contínuo ou intermitente) em meses que o título fica suspenso por atraso de pagamento, antes de ser cancelado (não aplicável a pagamento único).
-            type: integer
-            maxLength: 3
-            example: 10
-          termExtensionOption:
-            description: Alteração do prazo de vigência original, pela suspensão.
-            type: boolean
-            example: true
+      properties:
+        suspensionPeriod:
+          description: Prazo máximo (contínuo ou intermitente) em meses que o título fica suspenso por atraso de pagamento, antes de ser cancelado (não aplicável a pagamento único).
+          type: integer
+          maxLength: 3
+          example: 10
+        termExtensionOption:
+          description: Alteração do prazo de vigência original, pela suspensão.
+          type: boolean
+          example: true
     CapitalizationTitleContributionPayment:
       type: object
       description: Pagamento da contribuição
@@ -328,46 +328,46 @@ components:
         - updateIndex
       properties:
         paymentMethod:
-          description:  Meio de Pagamento utilizados para pagamento da contribuição.
+          description: Meio de Pagamento utilizados para pagamento da contribuição.
           type: array
           items:
             type: string
             example: CARTAO_CREDITO
-            enum: [CARTAO_CREDITO, CARTAO_DEBITO, DEBITO_CONTA_CORRENTE, DEBITO_CONTA_POUPANCA, BOLETO_BANCARIO, PIX, CONSIGNACAO_FOLHA_PAGAMENTO, PAGAMENTO_COM_PONTOS, OUTROS]
+            enum: [ CARTAO_CREDITO, CARTAO_DEBITO, DEBITO_CONTA_CORRENTE, DEBITO_CONTA_POUPANCA, BOLETO_BANCARIO, PIX, CONSIGNACAO_FOLHA_PAGAMENTO, PAGAMENTO_COM_PONTOS, OUTROS ]
         updateIndex:
           description: Índice utilizado na atualização dos pagamentos mensais (para títulos com mais de 12 meses de vigência)
           type: array
           items:
             type: string
             example: IPCA
-            enum: [IPCA, IGPM, INPC, TR, INDICE_REMUNERACAO_DEPOSITOS_POUPANCA, OUTROS]
+            enum: [ IPCA, IGPM, INPC, TR, INDICE_REMUNERACAO_DEPOSITOS_POUPANCA, OUTROS ]
         others:
-            type: array
-            description: Preenchida pelas participantes quando houver ‘Outros’ no campo.
-            items:
-                type: string
-                example: Índice de atualização
+          type: array
+          description: Preenchida pelas participantes quando houver ‘Outros’ no campo.
+          items:
+            type: string
+            example: Índice de atualização
     CapitalizationTitleredemption:
-        type: object
-        required:
+      type: object
+      required:
         - redemption
-        properties:
-            redemption:
-                description: Valor percentual (%) de resgate final permitido.
-                type: number
-                maxLength: 6
-                example: 151.23
+      properties:
+        redemption:
+          description: Valor percentual (%) de resgate final permitido.
+          type: number
+          maxLength: 6
+          example: 151.23
     CapitalizationTitleRaffle:
       description: Sorteio
       type: object
       required:
-       - timeInterval
-       - raffleQty
-       - raffleValue
-       - earlySettlementRaffle
-       - mandatoryContemplation
-       - RuleDescription
-       - minimumContemplationProbability
+        - timeInterval
+        - raffleQty
+        - raffleValue
+        - earlySettlementRaffle
+        - mandatoryContemplation
+        - ruleDescription
+        - minimumContemplationProbability
       properties:
         raffleQty:
           type: integer
@@ -380,7 +380,7 @@ components:
           items:
             type: string
             example: QUINZENAL
-            enum: [UNICO, DIARIO, SEMANAL, QUINZENAL, MENSAL, BIMESTRAL, TRIMESTRAL, QUADRIMESTRAL, SEMESTRAL, ANUAL, OUTROS]
+            enum: [ UNICO, DIARIO, SEMANAL, QUINZENAL, MENSAL, BIMESTRAL, TRIMESTRAL, QUADRIMESTRAL, SEMESTRAL, ANUAL, OUTROS ]
         raffleValue:
           type: integer
           description: Valor dos sorteios representado por múltiplo do valor de contribuição.
@@ -432,7 +432,7 @@ components:
           items:
             type: string
             example: PESSOAL_NATURAL
-            enum: [PESSOAL_NATURAL, PESSOA_JURIDICA]
+            enum: [ PESSOAL_NATURAL, PESSOA_JURIDICA ]
     Links:
       type: object
       properties:
@@ -563,16 +563,16 @@ components:
       description: Campo para exigir conexões por HTTPS e proteger contra certificados falsificados.
       schema:
         type: string
-        pattern:  '[\w\W\s]*'
+        pattern: '[\w\W\s]*'
     x-Content-Type-Options:
-      name: X-Content-Type-Options
+      name: x-Content-Type-Options
       in: header
       description: Campo para evitar que navegadores executem a detecção de MIME e interpretem respostas como HTML de forma inadequada.
       schema:
         type: string
         pattern: '[\w\W\s]*'
     x-Frame-Options:
-      name: X-Frame-Options
+      name: x-Frame-Options
       in: header
       description: Campo indica se o navegador deve ou não renderizar um frame.
       schema:

--- a/documentation/source/files/swagger/capitalization-title.yaml
+++ b/documentation/source/files/swagger/capitalization-title.yaml
@@ -528,13 +528,6 @@ components:
         type: integer
         default: 10
         minimum: 1
-    cnpjNumber:
-      name: cnpjNumber
-      in: path
-      description: Número de CNPJ.
-      required: true
-      schema:
-        type: string
     cache-Control:
       name: cache-control
       in: header

--- a/documentation/source/files/swagger/capitalization-title.yaml
+++ b/documentation/source/files/swagger/capitalization-title.yaml
@@ -26,8 +26,8 @@ paths:
         - $ref: '#/components/parameters/content-Security-Policy'
         - $ref: '#/components/parameters/content-Type'
         - $ref: '#/components/parameters/strict-Transport-Security'
-        - $ref: '#/components/parameters/x-Content-Type-Options'
-        - $ref: '#/components/parameters/x-Frame-Options'
+        - $ref: '#/components/parameters/xxx-Content-Type-Options'
+        - $ref: '#/components/parameters/xxx-Frame-Options'
         - $ref: '#/components/parameters/page'
         - $ref: '#/components/parameters/pageSize'
       responses:
@@ -557,15 +557,15 @@ components:
       schema:
         type: string
         pattern: '[\w\W\s]*'
-    x-Content-Type-Options:
-      name: x-Content-Type-Options
+    xxx-Content-Type-Options:
+      name: xxx-Content-Type-Options
       in: header
       description: Campo para evitar que navegadores executem a detecção de MIME e interpretem respostas como HTML de forma inadequada.
       schema:
         type: string
         pattern: '[\w\W\s]*'
-    x-Frame-Options:
-      name: x-Frame-Options
+    xxx-Frame-Options:
+      name: xxx-Frame-Options
       in: header
       description: Campo indica se o navegador deve ou não renderizar um frame.
       schema:

--- a/documentation/source/files/swagger/home-insurance.yaml
+++ b/documentation/source/files/swagger/home-insurance.yaml
@@ -26,8 +26,8 @@ paths:
         - $ref: '#/components/parameters/content-Security-Policy'
         - $ref: '#/components/parameters/content-Type'
         - $ref: '#/components/parameters/strict-Transport-Security'
-        - $ref: '#/components/parameters/x-Content-Type-Options'
-        - $ref: '#/components/parameters/x-Frame-Options'
+        - $ref: '#/components/parameters/xxx-Content-Type-Options'
+        - $ref: '#/components/parameters/xxx-Frame-Options'
         - $ref: '#/components/parameters/page'
         - $ref: '#/components/parameters/pageSize'
         - $ref: '#/components/parameters/commercializationArea'
@@ -529,15 +529,15 @@ components:
       schema:
         type: string
         pattern: '[\w\W\s]*'
-    x-Content-Type-Options:
-      name: x-Content-Type-Options
+    xxx-Content-Type-Options:
+      name: xxx-Content-Type-Options
       in: header
       description: Campo para evitar que navegadores executem a detecção de MIME e interpretem respostas como HTML de forma inadequada.
       schema:
         type: string
         pattern: '[\w\W\s]*'
-    x-Frame-Options:
-      name: x-Frame-Options
+    xxx-Frame-Options:
+      name: xxx-Frame-Options
       in: header
       description: Campo indica se o navegador deve ou não renderizar um frame.
       schema:

--- a/documentation/source/files/swagger/home-insurance.yaml
+++ b/documentation/source/files/swagger/home-insurance.yaml
@@ -1,36 +1,36 @@
 openapi: 3.0.0
 info:
   title: APIs Open Data do Open Insurance Brasil
-  description: 
+  description:
     API de informações de Seguro Residencial. Os recursos que podem ser consumidos pelos participantes conforme a regra 3.2.2 do manual de escopo de dados.
   version: 1.0.0
   contact:
-    url: 'https://http://novosite.susep.gov.br'
+    url: 'https://novosite.susep.gov.br'
 servers:
   - url: 'https://api.organizacao.com.br/open-insurance/products-services/v1'
     description: Servidor de Produção
   - url: 'https://api.organizacao.com.br/open-insurance/products-services/v1'
-    description: Servidor de Homologação  
+    description: Servidor de Homologação
 tags:
-- name: "home-insurance"
+  - name: 'home-insurance'
 paths:
-  /home-insurance/commercializationArea/{commercializationArea}:  
+  /home-insurance/commercializationArea/{commercializationArea}:
     get:
       tags:
         - home-insurance
       summary: Obtém informações de seguros residenciais
-      description: "Obtém informações de seguros redidenciais"
-      operationId: "getResidentialInsurance"
+      description: 'Obtém informações de seguros redidenciais'
+      operationId: 'getResidentialInsurance'
       parameters:
-        - $ref: "#/components/parameters/cache-Control"
-        - $ref: "#/components/parameters/content-Security-Policy"
-        - $ref: "#/components/parameters/content-Type"
-        - $ref: "#/components/parameters/strict-Transport-Security"
-        - $ref: "#/components/parameters/x-Content-Type-Options"
-        - $ref: "#/components/parameters/x-Frame-Options"
-        - $ref: "#/components/parameters/page"
-        - $ref: "#/components/parameters/pageSize"
-        - $ref: "#/components/parameters/commercializationArea"
+        - $ref: '#/components/parameters/cache-Control'
+        - $ref: '#/components/parameters/content-Security-Policy'
+        - $ref: '#/components/parameters/content-Type'
+        - $ref: '#/components/parameters/strict-Transport-Security'
+        - $ref: '#/components/parameters/x-Content-Type-Options'
+        - $ref: '#/components/parameters/x-Frame-Options'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
+        - $ref: '#/components/parameters/commercializationArea'
       responses:
         '200':
           description: Dados dos Seguros Residenciais
@@ -55,7 +55,11 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
         default:
-          $ref: '#/components/schemas/ResponseHomeInsuranceList'        
+          description: Resposta
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseHomeInsuranceList'
 components:
   schemas:
     ResponseHomeInsuranceList:
@@ -68,7 +72,7 @@ components:
         data:
           type: object
           required:
-            - HomeInsuranceBrand
+            - brand
           properties:
             brand:
               $ref: '#/components/schemas/HomeInsuranceBrand'
@@ -87,9 +91,9 @@ components:
           maxLength: 80
           example: EMPRESA A seguros
         company:
-          $ref: '#/components/schemas/HomeInsuranceCompany'  
+          $ref: '#/components/schemas/HomeInsuranceCompany'
     HomeInsuranceCompany:
-      type: array
+      type: object
       items:
         description: Informações referente a sociedade a qual a marca pertence.
         required:
@@ -105,10 +109,8 @@ components:
             type: string
             description: CNPJ da sociedade pertencente à marca.
             maxLength: 14
-            example: 12345678901234
-          products:  
-            type: object
-            description: Produtos de Seguro Residencial.
+            example: '12345678901234'
+          products:
             $ref: '#/components/schemas/HomeInsuranceProduct'
     HomeInsuranceProduct:
       type: array
@@ -126,9 +128,9 @@ components:
           - assistanceServices
           - termsAndConditions
           - validity
-          - customerService
+          - customerServices
           - premiumPayments
-          - minimumRequirement
+          - minimumRequirements
           - targetAudiences
         properties:
           name:
@@ -142,14 +144,14 @@ components:
             maxLength: 80
             example: 0000-0
           coverages:
-            $ref: '#/components/schemas/HomeInsuranceCoverages'          
+            $ref: '#/components/schemas/HomeInsuranceCoverages'
           propertyCharacteristics:
-            $ref: '#/components/schemas/HomeInsurancePropertyCharacteristics'     
+            $ref: '#/components/schemas/HomeInsurancePropertyCharacteristics'
           propertyZipCode:
             type: string
             description: Código de Endereçamento Postal do Imóvel
             maxLength: 8
-            example: "1311000"
+            example: '1311000'
           protective:
             type: boolean
             description: Protecionais - Indicativo de exigência de itens protecionais.
@@ -160,7 +162,7 @@ components:
               type: string
               description: Adicionais do Produto.
               example: SORTEIO_GRATUITO
-              enum: [SORTEIO_GRATUITO , CLUBE_BENEFICIOS , CASHBACK , DESCONTOS , OUTROS]
+              enum: [ SORTEIO_GRATUITO , CLUBE_BENEFICIOS , CASHBACK , DESCONTOS , OUTROS ]
           additionalOthers:
             type: string
             description: Campo aberto para descrição de cada participante ao selecionar o domínio ‘Outros’ no campo acima ‘Adicionais’.
@@ -170,32 +172,32 @@ components:
           termsAndConditions:
             $ref: '#/components/schemas/HomeInsuranceTermsAndConditions'
           validity:
-            $ref: '#/components/schemas/HomeInsuranceValidity'          
+            $ref: '#/components/schemas/HomeInsuranceValidity'
           customerServices:
-            type: array 
+            type: array
             description: Informações de pagamento de prêmio.
             items:
-                type: string
-                example: LIVRE ESCOLHA
-                enum: [REDE_REFERENCIADA , LIVRE_ESCOLHA , REDE_REFERENCIADA_LIVRE_ESCOLHA]
+              type: string
+              example: LIVRE_ESCOLHA
+              enum: [ REDE_REFERENCIADA , LIVRE_ESCOLHA , REDE_REFERENCIADA_LIVRE_ESCOLHA ]
           premiumRates:
-            type: array 
+            type: array
             description: Distribuição de frequência relativa aos valores referentes às taxas cobradas.
             items:
-                type: string            
+              type: string
           premiumPayments:
-            $ref: '#/components/schemas/HomeInsurancePremiumPayment'                 
+            $ref: '#/components/schemas/HomeInsurancePremiumPayment'
           minimumRequirements:
             type: array
             items:
-              $ref: '#/components/schemas/HomeInsuranceMinimumRequirements'   
-          targetAudiences:          
+              $ref: '#/components/schemas/HomeInsuranceMinimumRequirements'
+          targetAudiences:
             type: array
             items:
               type: string
               description: Público a quem se destina o produto
               example: PESSOA_NATURAL
-              enum: [PESSOA_NATURAL , PESSOA_JURIDICA, AMBAS]             
+              enum: [ PESSOA_NATURAL , PESSOA_JURIDICA, AMBAS ]
     HomeInsuranceMinimumRequirements:
       type: object
       description: Produtos de Seguro Residencial.
@@ -206,29 +208,26 @@ components:
         contractingType:
           type: string
           description: Tipo de contratação.
-          enum: [COLETIVO , INDIVIDUAL, AMBAS]         
+          enum: [ COLETIVO , INDIVIDUAL, AMBAS ]
         contractingMinRequirement:
           type: string
-          description: Campo aberto contendo todos os requisitos mínimos para contratação (possibilidade de incluir URL).              
+          description: Campo aberto contendo todos os requisitos mínimos para contratação (possibilidade de incluir URL).
           maxLength: 1024
           example: https://openinsurance.com.br/aaa
-    HomeInsuranceCoverageAttributes:     
+    HomeInsuranceCoverageAttributes:
       type: object
       description: Informações de cobertura do Seguro Residencial.
       required:
-       - minLMI
-       - maxLMI
-       - minDeductibleAmount
-       - insuredMandatoryParticipationPercentage
+        - minLMI
+        - maxLMI
+        - minDeductibleAmount
+        - insuredMandatoryParticipationPercentage
       properties:
         minLMI:
-          description: Lista com valor mínimo de LMI aceito pela sociedade para cada cobertura.
           $ref: '#/components/schemas/HomeInsuranceCovaregeAttibutesDetails'
         maxLMI:
-          description: Lista com valor máximo de LMI aceito pela sociedade para cada cobertura.
           $ref: '#/components/schemas/HomeInsuranceCovaregeAttibutesDetails'
         minDeductibleAmount:
-          description: Valor mínimo de franquia e participação obrigatória do segurado - Listagem de valor mínimo da franquia (Reais) e/ou Participação Obrigatória do Segurado (Percentual) estabelecida pela sociedade para cada tipo de cobertura do produto.
           $ref: '#/components/schemas/HomeInsuranceCovaregeAttibutesDetails'
         insuredMandatoryParticipationPercentage:
           type: number
@@ -240,22 +239,22 @@ components:
         - code
         - description
       properties:
-        code: 
+        code:
           type: string
           example: R$
-        description: 
+        description:
           type: string
           example: REAL
     HomeInsuranceCovaregeAttibutesDetails:
-        type: object
-        required:
-          - amount
-          - unit
-        properties:
-          amount:
-            type: number
-          unit:
-            $ref: '#/components/schemas/HomeInsuranceCovaregeAttibutesDetailsUnit'  
+      type: object
+      required:
+        - amount
+        - unit
+      properties:
+        amount:
+          type: number
+        unit:
+          $ref: '#/components/schemas/HomeInsuranceCovaregeAttibutesDetailsUnit'
     HomeInsuranceTermsAndConditions:
       type: array
       description: Informações dos termos e condições conforme número do processo SUSEP.
@@ -264,7 +263,7 @@ components:
         required:
           - susepProcessNumber
           - definition
-        properties:  
+        properties:
           susepProcessNumber:
             type: string
             description: Número do processo SUSEP.
@@ -276,60 +275,60 @@ components:
             maxLength: 1024
             example: https://openinsurance.com.br/aaa
     HomeInsuranceValidity:
-        type: array
-        description: Vigência
-        items:
-            type: object
-            required:
-              - term
-            properties:
-              term:
-                type: string
-                description: Prazo de vigência do seguro contratado Intervalo contínuo de tempo durante o qual está em vigor o contrato de seguro. (RESOLUÇÃO CNSP Nº 341/2016).
-                example: ANUAL
-                enum: [ANUAL , ANUAL_INTERMITENTE , PLURIANUAL , PLURIANUAL_INTERMITENTE , MENSAL, MENSAL_INTERMITENTE , DIARIO , DIARIO_INTERMITENTE, OUTROS]
-              termOthers:
-                type: string
-                description: Campo livre para descrição por cada participante ao selecionar o domínio “Outros” no campo Prazo (acima).
-                maxLength: 100
+      type: array
+      description: Vigência
+      items:
+        type: object
+        required:
+          - term
+        properties:
+          term:
+            type: string
+            description: Prazo de vigência do seguro contratado Intervalo contínuo de tempo durante o qual está em vigor o contrato de seguro. (RESOLUÇÃO CNSP Nº 341/2016).
+            example: ANUAL
+            enum: [ ANUAL , ANUAL_INTERMITENTE , PLURIANUAL , PLURIANUAL_INTERMITENTE , MENSAL, MENSAL_INTERMITENTE , DIARIO , DIARIO_INTERMITENTE, OUTROS ]
+          termOthers:
+            type: string
+            description: Campo livre para descrição por cada participante ao selecionar o domínio “Outros” no campo Prazo (acima).
+            maxLength: 100
     HomeInsurancePremiumPayment:
-        type: array 
-        description: Informações de pagamento de prêmio.
-        items:
-          type: object
-          required:
+      type: array
+      description: Informações de pagamento de prêmio.
+      items:
+        type: object
+        required:
           - paymentMethod
           - paymentType
-          properties:
-            paymentMethod:
-              type: string
-              description: Meio de pagamento escolhido pelo segurado.
-              example: CARTÃO DE CRÉDITO
-              enum: [CARTAO_CREDITO , CARTAO_DEBITO , DEBITO_CONTA_CORRENTE , DEBITO_CONTA_POUPANCA , BOLETO_BANCARIO , PIX , CONSIGINACAO_FOLHA_PAGAMENTO , PONTOS_PROGRAMAS_BENEFICIO, OUTROS]
-            paymentMethodDetail:
-              type: string
-              description: Campo aberto para detalhamento do campo ‘Outros’ por cada participante.
-              maxLength: 100
-            paymentType:
-              type: string
-              description: Forma de pagamento
-              example: PAGAMENTO_UNICO
-              enum: [PAGAMENTO_UNICO , PARCELADO, AMBOS]
-    HomeInsuranceAssistanceServices:    
+        properties:
+          paymentMethod:
+            type: string
+            description: Meio de pagamento escolhido pelo segurado.
+            example: CARTAO_CREDITO
+            enum: [ CARTAO_CREDITO , CARTAO_DEBITO , DEBITO_CONTA_CORRENTE , DEBITO_CONTA_POUPANCA , BOLETO_BANCARIO , PIX , CONSIGINACAO_FOLHA_PAGAMENTO , PONTOS_PROGRAMAS_BENEFICIO, OUTROS ]
+          paymentMethodDetail:
+            type: string
+            description: Campo aberto para detalhamento do campo ‘Outros’ por cada participante.
+            maxLength: 100
+          paymentType:
+            type: string
+            description: Forma de pagamento
+            example: PAGAMENTO_UNICO
+            enum: [ PAGAMENTO_UNICO , PARCELADO, AMBOS ]
+    HomeInsuranceAssistanceServices:
       type: array
       description: Agrupamento dos serviços de assistências disponíveis vinculado ao produto.
       items:
         type: object
         required:
-        - assistanceServicesPackage
-        - complementaryAssistanceServicesDetail
-        - chargeTypeSignaling
+          - assistanceServicesPackage
+          - complementaryAssistanceServicesDetail
+          - chargeTypeSignaling
         properties:
           assistanceServicesPackage:
             type: string
             description: Pacotes de Assistência.
             example: ATE_10_SERVICOS
-            enum: [ATE_10_SERVICOS, ATE_20_SERVICOS , ACIMA_20_SERVICOS, CUSTOMIZAVEL]
+            enum: [ ATE_10_SERVICOS, ATE_20_SERVICOS , ACIMA_20_SERVICOS, CUSTOMIZAVEL ]
           complementaryAssistanceServicesDetail:
             type: string
             description: Campo livre para descrição dos serviços ofertados por cada sociedade participante.
@@ -339,24 +338,24 @@ components:
             type: string
             description: Sinalização em campo exclusivo se o pacote de Assistência é gratuita ou contratada/paga.
             example: GRATUITA
-            enum: [GRATUITA, PAGO]
+            enum: [ GRATUITA, PAGO ]
     HomeInsuranceCoverages:
       type: array
       description: Listagem de coberturas incluídas no produto.
       items:
         type: object
         required:
-            - coverageType
-            - coverageDetail
-            - coveragePermissionSeparteAquisition
-            - coverageAttributes
+          - coverageType
+          - coverageDetail
+          - coveragePermissionSeparteAquisition
+          - coverageAttributes
         properties:
           coverageType:
             type: string
-            enum: [IMOVEL_BASICA , IMOVEL_AMPLA , DANOS_ELETRICOS , DANOS_POR_AGUA , ALAGAMENTO , RESPONSABILIDADE_CIVIL_FAMILIAR, RESPONSABILIDADE_CIVIL_DANOS_MORAIS , ROUBO_SUBTRACAO_BENS , ROUBO_SUBTRACAO_BENS_FORA_LOCAL_SEGURADO , TACOS_GOLFE_HOLE_ONE , PEQUENAS_REFORMAS_OBRAS , GREVES_TUMULTOS_LOCKOUT , MICROEMPREENDEDOR , ESCRITORIO_RESIDENCIA , DANOS_EQUIPAMENTOS_ELETRONICOS , QUEBRA_VIDROS , IMPACTO_VEICULOS , VENDAVAL , PERDA_PAGAMENTO_ALUGUEL , BICICLETA , RESPONSABILIDADE_CIVIL_BICICLETA , RC_EMPREGADOR , DESMORONAMENTO , DESPESAS_EXTRAORDINARIAS , JOIAS_OBRAS_ARTE , TERREMOTO , IMPACTO_AERONAVES , PAISAGISMO ,  INCENDIO , QUEDA_RAIO , EXPLOSAO, OUTRAS]
+            enum: [ IMOVEL_BASICA , IMOVEL_AMPLA , DANOS_ELETRICOS , DANOS_POR_AGUA , ALAGAMENTO , RESPONSABILIDADE_CIVIL_FAMILIAR, RESPONSABILIDADE_CIVIL_DANOS_MORAIS , ROUBO_SUBTRACAO_BENS , ROUBO_SUBTRACAO_BENS_FORA_LOCAL_SEGURADO , TACOS_GOLFE_HOLE_ONE , PEQUENAS_REFORMAS_OBRAS , GREVES_TUMULTOS_LOCKOUT , MICROEMPREENDEDOR , ESCRITORIO_RESIDENCIA , DANOS_EQUIPAMENTOS_ELETRONICOS , QUEBRA_VIDROS , IMPACTO_VEICULOS , VENDAVAL , PERDA_PAGAMENTO_ALUGUEL , BICICLETA , RESPONSABILIDADE_CIVIL_BICICLETA , RC_EMPREGADOR , DESMORONAMENTO , DESPESAS_EXTRAORDINARIAS , JOIAS_OBRAS_ARTE , TERREMOTO , IMPACTO_AERONAVES , PAISAGISMO ,  INCENDIO , QUEDA_RAIO , EXPLOSAO, OUTRAS ]
             description: Nome do tipo da cobertura.
             maxLength: 1000
-            example:  Escritório em Residência
+            example: ESCRITORIO_RESIDENCIA
           coverageDetail:
             type: string
             description: Campo aberto para detalhamento por coberturas possíveis dos produtos a ser feito por cada participante.
@@ -369,36 +368,36 @@ components:
           coverageAttributes:
             $ref: '#/components/schemas/HomeInsuranceCoverageAttributes'
     HomeInsurancePropertyCharacteristics:
-        type: array 
-        description: Caracteristicas do imóvel.
-        items:
-          type: object
-          required:
-            - propertyType
-            - propertyUsageType
-            - propertyBuildType
-            - destinationInsuredImportance
-          properties:
-            propertyType:             
-                description: Tipo de imóvel.           
-                type: string
-                example: CASA
-                enum: [CASA , APARTAMENTO]  
-            propertyBuildType:
-                type: string
-                description: Descrição do tipo de construção da propriedade.
-                example: ALVENARIA
-                enum: [ALVENARIA , MADEIRA , METALICA , MISTA]
-            propertyUsageType:
-                type: string 
-                description: Descrição do tipo de uso da propriedade.
-                example: HABITUAL
-                enum: [HABITUAL , VERANEIO , DESOCUPADO , CASA_ESCRITORIO , ALUGUEL_TEMPORADA]                         
-            destinationInsuredImportance:
-              type: string
-              description: Destinação da Importância Segurada.
-              example: PRÉDIO
-              enum: [PREDIO, CONTEUDO, AMBOS]   
+      type: array
+      description: Caracteristicas do imóvel.
+      items:
+        type: object
+        required:
+          - propertyType
+          - propertyUsageType
+          - propertyBuildType
+          - destinationInsuredImportance
+        properties:
+          propertyType:
+            description: Tipo de imóvel.
+            type: string
+            example: CASA
+            enum: [ CASA , APARTAMENTO ]
+          propertyBuildType:
+            type: string
+            description: Descrição do tipo de construção da propriedade.
+            example: ALVENARIA
+            enum: [ ALVENARIA , MADEIRA , METALICA , MISTA ]
+          propertyUsageType:
+            type: string
+            description: Descrição do tipo de uso da propriedade.
+            example: HABITUAL
+            enum: [ HABITUAL , VERANEIO , DESOCUPADO , CASA_ESCRITORIO , ALUGUEL_TEMPORADA ]
+          destinationInsuredImportance:
+            type: string
+            description: Destinação da Importância Segurada.
+            example: PREDIO
+            enum: [ PREDIO, CONTEUDO, AMBOS ]
     Links:
       type: object
       properties:
@@ -470,13 +469,13 @@ components:
                 description: 'Data e hora da consulta, conforme especificação RFC-3339, formato UTC.'
                 type: string
                 pattern: '[\w\W\s]*'
-                maxLength: 2048  
+                maxLength: 2048
                 format: date-time
                 example: '2021-08-20T08:30:00Z'
             additionalProperties: false
         meta:
           $ref: '#/components/schemas/Meta'
-      additionalProperties: false    
+      additionalProperties: false
   parameters:
     page:
       name: page
@@ -493,7 +492,7 @@ components:
       schema:
         type: integer
         default: 10
-        minimum: 1  
+        minimum: 1
     commercializationArea:
       name: commercializationArea
       in: path
@@ -506,7 +505,7 @@ components:
       in: header
       description: Controle de cache para evitar que informações confidenciais sejam armazenadas em cache.
       required: true
-      schema: 
+      schema:
         type: string
         pattern: '[\w\W\s]*'
     content-Security-Policy:
@@ -529,16 +528,16 @@ components:
       description: Campo para exigir conexões por HTTPS e proteger contra certificados falsificados.
       schema:
         type: string
-        pattern:  '[\w\W\s]*'
+        pattern: '[\w\W\s]*'
     x-Content-Type-Options:
-      name: X-Content-Type-Options
+      name: x-Content-Type-Options
       in: header
       description: Campo para evitar que navegadores executem a detecção de MIME e interpretem respostas como HTML de forma inadequada.
       schema:
         type: string
         pattern: '[\w\W\s]*'
     x-Frame-Options:
-      name: X-Frame-Options
+      name: x-Frame-Options
       in: header
       description: Campo indica se o navegador deve ou não renderizar um frame.
       schema:
@@ -556,7 +555,7 @@ components:
           authorizationUrl: 'https://authserver.example/authorization'
           tokenUrl: 'https://authserver.example/token'
           scopes:
-            financings: Escopo necessário para acesso à API. O controle dos endpoints específicos é feito via permissions.    
+            financings: Escopo necessário para acesso à API. O controle dos endpoints específicos é feito via permissions.
   responses:
 
     BadRequest:
@@ -606,5 +605,4 @@ components:
       content:
         application/json; charset=utf-8:
           schema:
-            $ref: '#/components/schemas/ResponseError'          
-  
+            $ref: '#/components/schemas/ResponseError'

--- a/documentation/source/files/swagger/life-pension.yaml
+++ b/documentation/source/files/swagger/life-pension.yaml
@@ -12,24 +12,24 @@ servers:
   - url: 'https://api.organizacao.com.br/open-insurance/products-services/v1'
     description: Servidor de Homologação
 tags:
-- name: "life-pension"
+  - name: 'life-pension'
 paths:
   /life-pension:
     get:
       tags:
         - life-pension
       summary: Obtém a lista dos produtos do tipo vida e previdência.
-      description: "Obtém a lista dos produtos do tipo vida e previdência."
-      operationId: "getLifePension"
+      description: 'Obtém a lista dos produtos do tipo vida e previdência.'
+      operationId: 'getLifePension'
       parameters:
-        - $ref: "#/components/parameters/cache-Control"
-        - $ref: "#/components/parameters/content-Security-Policy"
-        - $ref: "#/components/parameters/content-Type"
-        - $ref: "#/components/parameters/strict-Transport-Security"
-        - $ref: "#/components/parameters/x-Content-Type-Options"
-        - $ref: "#/components/parameters/x-Frame-Options"
-        - $ref: "#/components/parameters/page"
-        - $ref: "#/components/parameters/pageSize"
+        - $ref: '#/components/parameters/cache-Control'
+        - $ref: '#/components/parameters/content-Security-Policy'
+        - $ref: '#/components/parameters/content-Type'
+        - $ref: '#/components/parameters/strict-Transport-Security'
+        - $ref: '#/components/parameters/x-Content-Type-Options'
+        - $ref: '#/components/parameters/x-Frame-Options'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
       responses:
         '200':
           description: Dados dos produtos de Vida e Previdência
@@ -64,21 +64,21 @@ components:
     ResponseLifePensionList:
       type: array
       items:
-          type: object
-          required:
-            - identification
-            - products
-            - links
-            - meta
-          properties:
-            identification:
-              $ref: '#/components/schemas/LifePensionIdentification'
-            products:
-              $ref: '#/components/schemas/LifePensionProduct'
-            links:
-              $ref: '#/components/schemas/LinksPaginated'
-            meta:
-              $ref: '#/components/schemas/MetaPaginated'
+        type: object
+        required:
+          - identification
+          - products
+          - links
+          - meta
+        properties:
+          identification:
+            $ref: '#/components/schemas/LifePensionIdentification'
+          products:
+            $ref: '#/components/schemas/LifePensionProduct'
+          links:
+            $ref: '#/components/schemas/LinksPaginated'
+          meta:
+            $ref: '#/components/schemas/MetaPaginated'
     LifePensionIdentification:
       type: object
       description: Organização controladora do grupo.
@@ -101,90 +101,90 @@ components:
           type: string
           description: CNPJ da sociedade pertencente à marca.
           maxLength: 14
-          example: "27665207000131"
+          example: '27665207000131'
     LifePensionProduct:
-        type: array
-        items:
-          type: object
-          required:
-            - name
-            - code
-            - segment
-            - modality
-            - coverages
-            - minimumRequirements
-            - targetAudience
-          properties:
-            name:
-              type: string
-              description: Nome comercial do produto, pelo qual é identificado nos canais de distribuição e atendimento da sociedade.
-              maxLength: 80
-              example: Brasilprev Private Multimercado 2020
-            code:
-              type: string
-              description: Código único a ser definido pela sociedade.
-              maxLength: 80
-              example: "1234"
-            segment:
-              type: string
-              description: Segmento do qual se trata o produto contratado.
-              maxLength: 20
-              example: PREVIDENCIA
-              enum: [SEGURO_PESSOAS , PREVIDENCIA]
-            type:
-                type: string
-                description: Tipo do produto contratado.
-                maxLength: 20
-                example: PGBL
-                enum: [PGBL , PRGP , PAGP, PRSA, PRI, PDR, VGBL, VRGP, VAGP, VRSA, VRI, VDR, DEMAIS_PRODUTOS_PREVIDENCIA]
-            modality:
-              type: string
-              description: Modalidade do produto contratado.
-              maxLength: 25
-              example: CONTRIBUICAO_VARIAVEL
-              enum: [CONTRIBUICAO_VARIAVEL , BENEFICIO_DEFINIDO]
-            optionalCoverage:
-              type: string
-              description: Campo aberto (possibilidade de incluir URL).
-              maxLength: 1024
-            productDetails:
-              $ref: '#/components/schemas/LifePensionProductDetails'
-            minimumRequirements:
-                $ref: '#/components/schemas/LifePensionMinimumRequirements'
-            targetAudience:
-              type: string
-              description: Público-alvo.
-              example: PESSOA_NATURAL
-              maxLength: 15
-              enum: [PESSOA_NATURAL, PESSOA_JURIDICA]
+      type: array
+      items:
+        type: object
+        required:
+          - name
+          - code
+          - segment
+          - modality
+          #- coverages
+          - minimumRequirements
+          - targetAudience
+        properties:
+          name:
+            type: string
+            description: Nome comercial do produto, pelo qual é identificado nos canais de distribuição e atendimento da sociedade.
+            maxLength: 80
+            example: Brasilprev Private Multimercado 2020
+          code:
+            type: string
+            description: Código único a ser definido pela sociedade.
+            maxLength: 80
+            example: '1234'
+          segment:
+            type: string
+            description: Segmento do qual se trata o produto contratado.
+            maxLength: 20
+            example: PREVIDENCIA
+            enum: [ SEGURO_PESSOAS , PREVIDENCIA ]
+          type:
+            type: string
+            description: Tipo do produto contratado.
+            maxLength: 20
+            example: PGBL
+            enum: [ PGBL , PRGP , PAGP, PRSA, PRI, PDR, VGBL, VRGP, VAGP, VRSA, VRI, VDR, DEMAIS_PRODUTOS_PREVIDENCIA ]
+          modality:
+            type: string
+            description: Modalidade do produto contratado.
+            maxLength: 25
+            example: CONTRIBUICAO_VARIAVEL
+            enum: [ CONTRIBUICAO_VARIAVEL , BENEFICIO_DEFINIDO ]
+          optionalCoverage:
+            type: string
+            description: Campo aberto (possibilidade de incluir URL).
+            maxLength: 1024
+          productDetails:
+            $ref: '#/components/schemas/LifePensionProductDetails'
+          minimumRequirements:
+            $ref: '#/components/schemas/LifePensionMinimumRequirements'
+          targetAudience:
+            type: string
+            description: Público-alvo.
+            example: PESSOA_NATURAL
+            maxLength: 15
+            enum: [ PESSOA_NATURAL, PESSOA_JURIDICA ]
     LifePensionProductDetails:
       type: array
       items:
         type: object
         required:
           - susepProcessNumber
-          - type
+          #- type
           - contractTermsConditions
           - defferalPeriod
           - grantPeriodBenefit
           - costs
         properties:
-            susepProcessNumber:
-              type: string
-              description: Sequência numérica utilizada para consulta dos processos eletrônicos na SUSEP, com caracteres especiais.
-              example: 15414.614141/2020-71
-              maxLength: 30
-            contractTermsConditions:
-              type: string
-              description: Campo aberto (possibilidade de incluir URL).
-              example: https://example.com/mobilebanking
-              maxLength: 1024
-            defferalPeriod:
-              $ref: '#/components/schemas/LifePensionDefferalPeriod'
-            grantPeriodBenefit:
-              $ref: '#/components/schemas/LifePensionPeriodGrantBenefit'
-            costs:
-              $ref: '#/components/schemas/LifePensionCosts'
+          susepProcessNumber:
+            type: string
+            description: Sequência numérica utilizada para consulta dos processos eletrônicos na SUSEP, com caracteres especiais.
+            example: 15414.614141/2020-71
+            maxLength: 30
+          contractTermsConditions:
+            type: string
+            description: Campo aberto (possibilidade de incluir URL).
+            example: https://example.com/mobilebanking
+            maxLength: 1024
+          defferalPeriod:
+            $ref: '#/components/schemas/LifePensionDefferalPeriod'
+          grantPeriodBenefit:
+            $ref: '#/components/schemas/LifePensionPeriodGrantBenefit'
+          costs:
+            $ref: '#/components/schemas/LifePensionCosts'
     LifePensionDefferalPeriod:
       type: object
       required:
@@ -193,7 +193,7 @@ components:
         - otherMinimumPerformanceGarantees
         - reversalFinancialResults
         - minimumPremiumAmount
-        - prizePaymentMethod
+        #- prizePaymentMethod
         - permissonScheduledFinancialPayments
         - gracePeriodRedemption
         - gracePeriodBetweenRedemptionRequests
@@ -214,7 +214,7 @@ components:
           description: Indice garantido que remunera o plano durante a fase de diferimento/ acumulação.
           example: IPCA
           maxLength: 12
-          enum: [IPCA,IGP-M,INPC]
+          enum: [ IPCA,IGP-M,INPC ]
         otherMinimumPerformanceGarantees:
           type: string
           description: Para produtos do tipo PDR e VDR, indicação do percentual e do índice de ampla divulgação utilizados como garantia mínima de desempenho. Em %.
@@ -253,7 +253,7 @@ components:
             description: Meio de pagamento escolhido pelo segurado.
             example: CARTAO_CREDITO
             maxLength: 20
-            enum: [CARTAO_CREDITO, DEBITO_CONTA, DEBITO_CONTA_POUPANCA, BOLETO_BANCARIO, PIX, CARTAO_DEBITO, REGRA_PARCEIRO, CONSIGNACAO_FOLHA_PAGAMENTO, PONTOS_PROGRAMA_BENEFICIO, TED_DOC, OUTROS]
+            enum: [ CARTAO_CREDITO, DEBITO_CONTA, DEBITO_CONTA_POUPANCA, BOLETO_BANCARIO, PIX, CARTAO_DEBITO, REGRA_PARCEIRO, CONSIGNACAO_FOLHA_PAGAMENTO, PONTOS_PROGRAMA_BENEFICIO, TED_DOC, OUTROS ]
         permissionExtraordinaryContributions:
           type: boolean
           description: Se ficam permitidos aportes extraordinários.
@@ -295,61 +295,61 @@ components:
         investimentFunds:
           $ref: '#/components/schemas/LifePensionInvestmentFunds'
     LifePensionInvestmentFunds:
-        type: array
-        description: Lista com as informações do(s) Fundo(s) de Investimento(s) disponíveis para o período de diferimento/acumulação.
-        items:
-            type: object
-            required:
-              - cnpjNumber
-              - companyName
-              - maximumAdministrationFee
-              - typePerformanceFee
-              - eligibilityRule
-              - minimumContributionAmount
-              - minimumMathematicalProvisionAmount
-            properties:
-                cnpjNumber:
-                  type: string
-                  description: Número de CNPJ.
-                  example: 13.456.789/0001-12
-                  maxLength: 18
-                companyName:
-                  type: string
-                  description: Nome Fantasia.
-                  example:  EYPREV
-                  maxLength: 80
-                maximumAdministrationFee:
-                  type: number
-                  description:  Taxa Máxima de Administração – em %.
-                  example: 20.1
-                  maxLength: 5
-                typePerformanceFee:
-                  type: array
-                  items:
-                    type: string
-                    description: Tipo de Taxa de Performance
-                    example: DIRETAMENTE
-                    maxLength: 15
-                    enum: [DIRETAMENTE, INDIRETAMENTE, NAO_APLICA]
-                maximumPerformanceFee:
-                  type: number
-                  description:  Taxa Máxima de Performance. Caso o Tipo de Taxa de Performance seja ‘Diretamente’.
-                  maxLength: 5
-                  example: 20.0
-                eligibilityRule:
-                  type: boolean
-                  description:  Regra de Eligibilidade.
-                  example: true
-                minimumContributionAmount:
-                  type: number
-                  description: Valor Mínimo de Contribuição. Regra de Elegibilidade. Caso a Regra de Elegibilidade SIM.
-                  example: 1000
-                  maxLength: 5
-                minimumMathematicalProvisionAmount:
-                  type: number
-                  description: Valor Mínimo Provisão Matemática. Caso a Regra de Elegibilidade SIM.
-                  maxLength: 5
-                  example: 1000
+      type: array
+      description: Lista com as informações do(s) Fundo(s) de Investimento(s) disponíveis para o período de diferimento/acumulação.
+      items:
+        type: object
+        required:
+          - cnpjNumber
+          - companyName
+          - maximumAdministrationFee
+          - typePerformanceFee
+          - eligibilityRule
+          - minimumContributionAmount
+          - minimumMathematicalProvisionAmount
+        properties:
+          cnpjNumber:
+            type: string
+            description: Número de CNPJ.
+            example: 13.456.789/0001-12
+            maxLength: 18
+          companyName:
+            type: string
+            description: Nome Fantasia.
+            example: EYPREV
+            maxLength: 80
+          maximumAdministrationFee:
+            type: number
+            description: Taxa Máxima de Administração – em %.
+            example: 20.1
+            maxLength: 5
+          typePerformanceFee:
+            type: array
+            items:
+              type: string
+              description: Tipo de Taxa de Performance
+              example: DIRETAMENTE
+              maxLength: 15
+              enum: [ DIRETAMENTE, INDIRETAMENTE, NAO_APLICA ]
+          maximumPerformanceFee:
+            type: number
+            description: Taxa Máxima de Performance. Caso o Tipo de Taxa de Performance seja ‘Diretamente’.
+            maxLength: 5
+            example: 20.0
+          eligibilityRule:
+            type: boolean
+            description: Regra de Eligibilidade.
+            example: true
+          minimumContributionAmount:
+            type: number
+            description: Valor Mínimo de Contribuição. Regra de Elegibilidade. Caso a Regra de Elegibilidade SIM.
+            example: 1000
+            maxLength: 5
+          minimumMathematicalProvisionAmount:
+            type: number
+            description: Valor Mínimo Provisão Matemática. Caso a Regra de Elegibilidade SIM.
+            maxLength: 5
+            example: 1000
     LifePensionPeriodGrantBenefit:
       type: object
       required:
@@ -367,7 +367,7 @@ components:
             description: Modalidades de renda disponíveis para contratação. A considerar os seguintes domínios
             example: RENDA_VITALICIA
             maxLength: 100
-            enum: [PAGAMENTO_UNICO, RENDA_PRAZO_CERTO, RENDA_TEMPORARIA, RENDA_TEMPORARIA_REVERSIVEL, RENDA_TEMPORARIA_MINMO_GARANTIDO, RENDA_TEMPORARIA_REVERSIVEL_MININO_GARANTIDO, RENDA_VITALICIA, RENDA_VITALICIA_REVERSIVEL_BENEFICIARIO_INDICADO, RENDA_VITALICIA_CONJUGE_CONTINUIDADE_MENORES, RENDA_VITALICIA_MINIMO_GARANTIDO, RENDA_VITALICIA_PRAZO_MINIMO_GRANTIDO]
+            enum: [ PAGAMENTO_UNICO, RENDA_PRAZO_CERTO, RENDA_TEMPORARIA, RENDA_TEMPORARIA_REVERSIVEL, RENDA_TEMPORARIA_MINMO_GARANTIDO, RENDA_TEMPORARIA_REVERSIVEL_MININO_GARANTIDO, RENDA_VITALICIA, RENDA_VITALICIA_REVERSIVEL_BENEFICIARIO_INDICADO, RENDA_VITALICIA_CONJUGE_CONTINUIDADE_MENORES, RENDA_VITALICIA_MINIMO_GARANTIDO, RENDA_VITALICIA_PRAZO_MINIMO_GRANTIDO ]
         biometricTable:
           type: array
           items:
@@ -375,7 +375,7 @@ components:
             description: Tábua biométrica é o instrumento que mede a duração da vida humana (também conhecida como tábua de mortalidade) ou a probabilidade de entrada em invalidez e é um parâmetro utilizado para tarifar os planos de previdência complementar aberta.
             example: AT_2000_FEMALE_SUAVIZADA_15
             maxLength: 100
-            enum: [AT_2000_MALE, AT_2000_FEMALE, AT_2000_MALE_FEMALE, AT_2000_MALE_SUAVIZADA_10, AT_2000_FEMALE_SUAVIZADA_10, AT_2000_MALE_FEMALE_SUAVIZADA_10, AT_2000_MALE_SUAVIZADA_15, AT_2000_FEMALE_SUAVIZADA_15, AT_2000_MALE_FEMALE_SUAVIZADA_15, AT_83_MALE, AT_83_FEMALE, AT_83_MALE_FEMALE, BR_EMSSB_MALE, BR_EMSSB_FEMALE, BR_EMSSB_MALE_FEMALE]
+            enum: [ AT_2000_MALE, AT_2000_FEMALE, AT_2000_MALE_FEMALE, AT_2000_MALE_SUAVIZADA_10, AT_2000_FEMALE_SUAVIZADA_10, AT_2000_MALE_FEMALE_SUAVIZADA_10, AT_2000_MALE_SUAVIZADA_15, AT_2000_FEMALE_SUAVIZADA_15, AT_2000_MALE_FEMALE_SUAVIZADA_15, AT_83_MALE, AT_83_FEMALE, AT_83_MALE_FEMALE, BR_EMSSB_MALE, BR_EMSSB_FEMALE, BR_EMSSB_MALE_FEMALE ]
         interestRate:
           type: number
           description: Taxa de juros garantida utilizada para conversão em renda. Em %.
@@ -386,7 +386,7 @@ components:
           description: É o índice contratado para atualização monetária dos valores relativos ao plano, na forma estabelecida por este regulamento.
           example: IPCA
           maxLength: 20
-          enum: [IPCA, IGP-M, INPC]
+          enum: [ IPCA, IGP-M, INPC ]
         reversalResultsFinancial:
           type: number
           description: Percentual de reversão de excedente financeiro na concessão. Em %.
@@ -432,7 +432,7 @@ components:
           description: O tipo de serviço contratado.
           example: INDIVIDUAL
           maxLength: 15
-          enum: [COLETIVO_AVERBADO, COLETIVO_INSTITUIDO, INDIVIDUAL]
+          enum: [ COLETIVO_AVERBADO, COLETIVO_INSTITUIDO, INDIVIDUAL ]
         participantQualified:
           type: boolean
           description: Indicação se o plano é destinado para participante qualificado.
@@ -571,16 +571,16 @@ components:
       description: Campo para exigir conexões por HTTPS e proteger contra certificados falsificados.
       schema:
         type: string
-        pattern:  '[\w\W\s]*'
+        pattern: '[\w\W\s]*'
     x-Content-Type-Options:
-      name: X-Content-Type-Options
+      name: x-Content-Type-Options
       in: header
       description: Campo para evitar que navegadores executem a detecção de MIME e interpretem respostas como HTML de forma inadequada.
       schema:
         type: string
         pattern: '[\w\W\s]*'
     x-Frame-Options:
-      name: X-Frame-Options
+      name: x-Frame-Options
       in: header
       description: Campo indica se o navegador deve ou não renderizar um frame.
       schema:

--- a/documentation/source/files/swagger/life-pension.yaml
+++ b/documentation/source/files/swagger/life-pension.yaml
@@ -536,13 +536,6 @@ components:
         type: integer
         default: 10
         minimum: 1
-    cnpjNumber:
-      name: cnpjNumber
-      in: path
-      description: Número de CNPJ.
-      required: true
-      schema:
-        type: string
     cache-Control:
       name: cache-control
       in: header

--- a/documentation/source/files/swagger/life-pension.yaml
+++ b/documentation/source/files/swagger/life-pension.yaml
@@ -26,8 +26,8 @@ paths:
         - $ref: '#/components/parameters/content-Security-Policy'
         - $ref: '#/components/parameters/content-Type'
         - $ref: '#/components/parameters/strict-Transport-Security'
-        - $ref: '#/components/parameters/x-Content-Type-Options'
-        - $ref: '#/components/parameters/x-Frame-Options'
+        - $ref: '#/components/parameters/xxx-Content-Type-Options'
+        - $ref: '#/components/parameters/xxx-Frame-Options'
         - $ref: '#/components/parameters/page'
         - $ref: '#/components/parameters/pageSize'
       responses:
@@ -565,15 +565,15 @@ components:
       schema:
         type: string
         pattern: '[\w\W\s]*'
-    x-Content-Type-Options:
-      name: x-Content-Type-Options
+    xxx-Content-Type-Options:
+      name: xxx-Content-Type-Options
       in: header
       description: Campo para evitar que navegadores executem a detecção de MIME e interpretem respostas como HTML de forma inadequada.
       schema:
         type: string
         pattern: '[\w\W\s]*'
-    x-Frame-Options:
-      name: x-Frame-Options
+    xxx-Frame-Options:
+      name: xxx-Frame-Options
       in: header
       description: Campo indica se o navegador deve ou não renderizar um frame.
       schema:

--- a/documentation/source/files/swagger/metrics.yaml
+++ b/documentation/source/files/swagger/metrics.yaml
@@ -4,28 +4,28 @@ info:
   description: As API's administrativas são recursos que podem ser consumidos apenas pelo diretório para avaliação e controle da qualidade dos serviços fornecidos pelas instituições
   version: 1.0.0
   contact:
-    url: 'https://http://novosite.susep.gov.br'
+    url: 'https://novosite.susep.gov.br'
 servers:
   - url: 'http://api.organizacao.com.br/open-insurance/admin/v1'
 tags:
-- name: "Metrics"
+  - name: 'Metrics'
 paths:
-  /metrics:  
+  /metrics:
     get:
       tags:
         - Metrics
       summary: Obtém as métricas de disponibilidade das APIs
-      description: "Obtém as métricas de disponibilidade das APIs"
-      operationId: "getMetrics"
+      description: 'Obtém as métricas de disponibilidade das APIs'
+      operationId: 'getMetrics'
       parameters:
-        - $ref: "#/components/parameters/cache-Control"
-        - $ref: "#/components/parameters/content-Security-Policy"
-        - $ref: "#/components/parameters/content-Type"
-        - $ref: "#/components/parameters/strict-Transport-Security"
-        - $ref: "#/components/parameters/x-Content-Type-Options"
-        - $ref: "#/components/parameters/x-Frame-Options"
-        - $ref: "#/components/parameters/page"
-        - $ref: "#/components/parameters/pageSize"
+        - $ref: '#/components/parameters/cache-Control'
+        - $ref: '#/components/parameters/content-Security-Policy'
+        - $ref: '#/components/parameters/content-Type'
+        - $ref: '#/components/parameters/strict-Transport-Security'
+        - $ref: '#/components/parameters/x-Content-Type-Options'
+        - $ref: '#/components/parameters/x-Frame-Options'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
         - in: query
           name: period
           schema:
@@ -398,7 +398,7 @@ components:
       in: header
       description: Controle de cache para evitar que informações confidenciais sejam armazenadas em cache.
       required: true
-      schema: 
+      schema:
         type: string
         pattern: '[\w\W\s]*'
     content-Security-Policy:
@@ -421,18 +421,18 @@ components:
       description: Campo para exigir conexões por HTTPS e proteger contra certificados falsificados.
       schema:
         type: string
-        pattern:  '[\w\W\s]*'
+        pattern: '[\w\W\s]*'
     x-Content-Type-Options:
-      name: X-Content-Type-Options
+      name: x-Content-Type-Options
       in: header
       description: Campo para evitar que navegadores executem a detecção de MIME e interpretem respostas como HTML de forma inadequada.
       schema:
         type: string
         pattern: '[\w\W\s]*'
     x-Frame-Options:
-      name: X-Frame-Options
+      name: x-Frame-Options
       in: header
       description: Campo indica se o navegador deve ou não renderizar um frame.
       schema:
         type: string
-        pattern: '[\w\W\s]*'    
+        pattern: '[\w\W\s]*'

--- a/documentation/source/files/swagger/metrics.yaml
+++ b/documentation/source/files/swagger/metrics.yaml
@@ -22,8 +22,8 @@ paths:
         - $ref: '#/components/parameters/content-Security-Policy'
         - $ref: '#/components/parameters/content-Type'
         - $ref: '#/components/parameters/strict-Transport-Security'
-        - $ref: '#/components/parameters/x-Content-Type-Options'
-        - $ref: '#/components/parameters/x-Frame-Options'
+        - $ref: '#/components/parameters/xxx-Content-Type-Options'
+        - $ref: '#/components/parameters/xxx-Frame-Options'
         - $ref: '#/components/parameters/page'
         - $ref: '#/components/parameters/pageSize'
         - in: query
@@ -422,15 +422,15 @@ components:
       schema:
         type: string
         pattern: '[\w\W\s]*'
-    x-Content-Type-Options:
-      name: x-Content-Type-Options
+    xxx-Content-Type-Options:
+      name: xxx-Content-Type-Options
       in: header
       description: Campo para evitar que navegadores executem a detecção de MIME e interpretem respostas como HTML de forma inadequada.
       schema:
         type: string
         pattern: '[\w\W\s]*'
-    x-Frame-Options:
-      name: x-Frame-Options
+    xxx-Frame-Options:
+      name: xxx-Frame-Options
       in: header
       description: Campo indica se o navegador deve ou não renderizar um frame.
       schema:

--- a/documentation/source/files/swagger/pension-plan.yaml
+++ b/documentation/source/files/swagger/pension-plan.yaml
@@ -14,7 +14,7 @@ servers:
 tags:
   - name: 'pension-plan'
 paths:
-  /pension-plan/:
+  /pension-plan:
     get:
       tags:
         - pension-plan
@@ -593,13 +593,6 @@ components:
         type: integer
         default: 10
         minimum: 1
-    cnpjNumber:
-      name: cnpjNumber
-      in: path
-      description: Número de CNPJ.
-      required: true
-      schema:
-        type: string
     cache-Control:
       name: cache-control
       in: header

--- a/documentation/source/files/swagger/pension-plan.yaml
+++ b/documentation/source/files/swagger/pension-plan.yaml
@@ -1,35 +1,35 @@
 openapi: 3.0.0
 info:
   title: APIs Open Data do Open Insurance Brasil
-  description: 
+  description:
     API de informações de Plano de Previdência com cobertura de risco. Os recursos que podem ser consumidos pelos participantes conforme a regra 3.1.2 do manual de escopo de dados.
   version: 1.0.0
   contact:
-    url: 'https://http://novosite.susep.gov.br'
+    url: 'https://novosite.susep.gov.br'
 servers:
   - url: 'https://api.organizacao.com.br/open-insurance/products-services/v1'
     description: Servidor de Produção
   - url: 'https://api.organizacao.com.br/open-insurance/products-services/v1'
-    description: Servidor de Homologação  
+    description: Servidor de Homologação
 tags:
-- name: "pension-plan"
+  - name: 'pension-plan'
 paths:
   /pension-plan/:
     get:
       tags:
         - pension-plan
       summary: Obtém informações de plano de previdência com cobertura de risco
-      description: "Obtém informações de plano de previdência com cobertura de risco"
-      operationId: "getPensionPlan"
+      description: 'Obtém informações de plano de previdência com cobertura de risco'
+      operationId: 'getPensionPlan'
       parameters:
-        - $ref: "#/components/parameters/cache-Control"
-        - $ref: "#/components/parameters/content-Security-Policy"
-        - $ref: "#/components/parameters/content-Type"
-        - $ref: "#/components/parameters/strict-Transport-Security"
-        - $ref: "#/components/parameters/x-Content-Type-Options"
-        - $ref: "#/components/parameters/x-Frame-Options"
-        - $ref: "#/components/parameters/page"
-        - $ref: "#/components/parameters/pageSize"
+        - $ref: '#/components/parameters/cache-Control'
+        - $ref: '#/components/parameters/content-Security-Policy'
+        - $ref: '#/components/parameters/content-Type'
+        - $ref: '#/components/parameters/strict-Transport-Security'
+        - $ref: '#/components/parameters/x-Content-Type-Options'
+        - $ref: '#/components/parameters/x-Frame-Options'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
       responses:
         '200':
           description: Dados dos Plano de Previdência com cobertura de risco
@@ -38,9 +38,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/ResponsePensionPlanList'
         '201':
-          $ref: '#/components/responses/Created' 
+          $ref: '#/components/responses/Created'
         '204':
-          $ref: '#/components/responses/NoContent' 
+          $ref: '#/components/responses/NoContent'
         '304':
           $ref: '#/components/responses/NotModified'
         '400':
@@ -58,19 +58,23 @@ paths:
         '410':
           $ref: '#/components/responses/Gone'
         '415':
-           $ref: '#/components/responses/UnsupportedMediaType'
+          $ref: '#/components/responses/UnsupportedMediaType'
         '422':
-           $ref: '#/components/responses/UnprocessableEntity'
+          $ref: '#/components/responses/UnprocessableEntity'
         '429':
           $ref: '#/components/responses/TooManyRequests'
         '500':
           $ref: '#/components/responses/InternalServerError'
         '503':
-         $ref: '#/components/responses/ServiceUnavailable'
+          $ref: '#/components/responses/ServiceUnavailable'
         '504':
-         $ref: '#/components/responses/GatewayTimeout'
+          $ref: '#/components/responses/GatewayTimeout'
         default:
-          $ref: '#/components/schemas/ResponsePensionPlanList'               
+          description: Resposta
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponsePensionPlanList'
 components:
   schemas:
     ResponsePensionPlanList:
@@ -85,10 +89,10 @@ components:
           description: 'Data e hora da consulta, conforme especificação RFC-3339, formato UTC.'
           type: string
           pattern: '[\w\W\s]*'
-          maxLength: 2048  
+          maxLength: 2048
           format: date-time
           example: '2021-08-20T08:30:00Z'
-        data: 
+        data:
           type: object
         brand:
           $ref: '#/components/schemas/PensionPlanBrand'
@@ -108,14 +112,14 @@ components:
           description: Nome da marca reportada pelo participante do Open Insurance. O conceito a que se refere a marca é em essência uma promessa das sociedades sob ela em fornecer uma série específica de atributos, benefícios e serviços uniformes aos clientes.
           example: EMPRESA
         companies:
-          $ref: '#/components/schemas/PensionPlanCompany'  
+          $ref: '#/components/schemas/PensionPlanCompany'
     PensionPlanCompany:
       type: object
       description: Informações referente a sociedade a qual a marca pertence.
       required:
         - name
         - cnpjNumber
-        - product
+        - products
       properties:
         name:
           type: string
@@ -124,8 +128,8 @@ components:
         cnpjNumber:
           type: string
           description: CNPJ da sociedade pertencente à marca.
-          example: 45086338000178
-        products:          
+          example: '45086338000178'
+        products:
           $ref: '#/components/schemas/PensionPlanProduct'
     PensionPlanProduct:
       type: array
@@ -135,7 +139,7 @@ components:
         required:
           - name
           - code
-          - modality 
+          - modality
           - coverages
           - termsAndConditions
           - premiumUpdateIndex
@@ -157,37 +161,37 @@ components:
           modality:
             type: string
             description: Lista padronizada de modalidades de coberturas  incluídas no produto.
-            example: PENSAO
-            enum: [PECULIO,
-                   RENDA,
+            example: PENSAO_PRAZO_CERTO
+            enum: [ PECULIO,
+                    RENDA,
                     PENSAO_PRAZO_CERTO,
                     PENSAO_MENORES_21,
                     PENSAO_MENORES_24,
                     PENSAO_CONJUGE_VITALICIA,
                     PENSAO_CONJUGE_TEMPORARIA
-                    ]
+            ]
           coverages:
             type: array
             items:
               type: object
               properties:
-                coverage:        
+                coverage:
                   type: string
                   description: Formas de coberturas.
                   example: INVALIDEZ
-                  enum: [MORTE, INVALIDEZ]
+                  enum: [ MORTE, INVALIDEZ ]
                 coveragesAttributes:
                   $ref: '#/components/schemas/PensionPlanCoverageAttributes'
                 coveragePeriod:
                   type: string
                   description: Formas de coberturas.
-                  example: Vitalícia
-                  enum: [VITALICIA, TEMPORARIA]
-          additional:         
+                  example: VITALICIA
+                  enum: [ VITALICIA, TEMPORARIA ]
+          additional:
             type: string
             description: Adicional ao plano.
-            enum: [SORTEIO, OUTROS]
-          additionalOthers: 
+            enum: [ SORTEIO, OUTROS ]
+          additionalOthers:
             type: string
             description: Lista a ser preenchida pelas participantes quando houver ‘Outros’ no campo ‘additional’
           assistanceType:
@@ -195,59 +199,59 @@ components:
             description: Tipos de assistências.
             items:
               type: string
-              example: Funeral
-              enum: [ACOMPANHANTE_CASO_HOSPITALIZACAO_PROLONGADA,
-                ARQUITETO_VIRTUAL,
-                ASSESSORIA_FINANCEIRA,
-                AUTOMOVEL,
-                AUXILIO_NATALIDADE,
-                AVALIACAO_CLINICA_PREVENTIVA,
-                BOLSA_PROTEGIDA,
-                CESTA_BASICA,
-                CHECKUP_ODONTOLOGICO,
-                CLUBE_DE_VANTAGENS_BENEFICIOS,
-                CONVALESCENCIA,
-                DECESSO_FAMILIAR_E_OU_INDIVIDUAL,
-                DESCONTO_FARMACIAS_MEDICAMENTOS,
-                DESPESAS_FARMACEUTICAS_VIAGEM,
-                DIGITAL,
-                EDUCACIONAL,
-                EMPRESARIAL,
-                ENTRETENIMENTO,
-                EQUIPAMENTOS_MEDICOS,
-                FIANCAS_E_DESPESAS_LEGAIS,
-                FISIOTERAPIA,
-                FUNERAL,
-                HELP_LINE,
-                HOSPEDAGEM_DE_ACOMPANHANTE,
-                INTERRUPCAO_DA_VIAGEM,
-                INVENTARIO,
-                MAIS_EM_VIDA,
-                MAMAE_BEBE,
-                MEDICA_POR_ACIDENTE_OU_DOENCA,
-                MOTOCICLETA,
-                MULHER,
-                NUTRICIONISTA,
-                ODONTOLOGICA,
-                ORIENTACAO_FITNESS,
-                ORIENTACAO_JURIDICA,
-                ORIENTACAO_PSICOSSOCIAL_FAMILIAR,
-                PERDA_ROUBO_CARTAO,
-                PET,
-                PRORROGACAO_DE_ESTADIA,
-                PROTECAO_DE_DADOS,
-                RECOLOCACAO_PROFISSIONAL,
-                REDE_DESCONTO_NUTRICIONAL,
-                RESIDENCIAL,
-                RETORNO_MENORES_E_OU_SEGURADO,
-                SAQUE_SOB_COACAO,
-                SAUDE_BEMESTAR,
-                SEGUNDA_OPINIAO_MEDICA,
-                SENIOR,
-                SUSTENTAVEL_(DESCARTE_ECOLOGICO),
-                TELEMEDICINA,
-                VIAGEM,
-                VITIMAS]
+              example: FUNERAL
+              enum: [ ACOMPANHANTE_CASO_HOSPITALIZACAO_PROLONGADA,
+                      ARQUITETO_VIRTUAL,
+                      ASSESSORIA_FINANCEIRA,
+                      AUTOMOVEL,
+                      AUXILIO_NATALIDADE,
+                      AVALIACAO_CLINICA_PREVENTIVA,
+                      BOLSA_PROTEGIDA,
+                      CESTA_BASICA,
+                      CHECKUP_ODONTOLOGICO,
+                      CLUBE_DE_VANTAGENS_BENEFICIOS,
+                      CONVALESCENCIA,
+                      DECESSO_FAMILIAR_E_OU_INDIVIDUAL,
+                      DESCONTO_FARMACIAS_MEDICAMENTOS,
+                      DESPESAS_FARMACEUTICAS_VIAGEM,
+                      DIGITAL,
+                      EDUCACIONAL,
+                      EMPRESARIAL,
+                      ENTRETENIMENTO,
+                      EQUIPAMENTOS_MEDICOS,
+                      FIANCAS_E_DESPESAS_LEGAIS,
+                      FISIOTERAPIA,
+                      FUNERAL,
+                      HELP_LINE,
+                      HOSPEDAGEM_DE_ACOMPANHANTE,
+                      INTERRUPCAO_DA_VIAGEM,
+                      INVENTARIO,
+                      MAIS_EM_VIDA,
+                      MAMAE_BEBE,
+                      MEDICA_POR_ACIDENTE_OU_DOENCA,
+                      MOTOCICLETA,
+                      MULHER,
+                      NUTRICIONISTA,
+                      ODONTOLOGICA,
+                      ORIENTACAO_FITNESS,
+                      ORIENTACAO_JURIDICA,
+                      ORIENTACAO_PSICOSSOCIAL_FAMILIAR,
+                      PERDA_ROUBO_CARTAO,
+                      PET,
+                      PRORROGACAO_DE_ESTADIA,
+                      PROTECAO_DE_DADOS,
+                      RECOLOCACAO_PROFISSIONAL,
+                      REDE_DESCONTO_NUTRICIONAL,
+                      RESIDENCIAL,
+                      RETORNO_MENORES_E_OU_SEGURADO,
+                      SAQUE_SOB_COACAO,
+                      SAUDE_BEMESTAR,
+                      SEGUNDA_OPINIAO_MEDICA,
+                      SENIOR,
+                      SUSTENTAVEL_(DESCARTE_ECOLOGICO),
+                      TELEMEDICINA,
+                      VIAGEM,
+                      VITIMAS ]
           assistanceTypeOthers:
             type: array
             description: Outros tipos de assistências.
@@ -256,31 +260,31 @@ components:
           termAndCondition:
             type: array
             items:
-              $ref: '#/components/schemas/PensionPlanTerms'          
+              $ref: '#/components/schemas/PensionPlanTerms'
           updatePMBaC:
             $ref: '#/components/schemas/PensionPlanUpdatePMBaC'
           premiumUpdateIndex:
             type: string
             description: Índice utilizado na atualização do prêmio/contribuição e do capital segurado/benefício
-            enum: [IPCA, IGPM, INPC]
+            enum: [ IPCA, IGPM, INPC ]
           ageReframing:
             $ref: '#/components/schemas/PensionPlanAgeReframing'
           financialRegimeContractType:
             type: string
             description: Tipo de contratação de regime financeiro.
-            example: Repartição Simples
-            enum: [REPARTICAO_SIMPLES, REPARTICAO_CAPITAIS_COBERTURA, CAPITALIZACAO]
+            example: REPARTICAO_SIMPLES
+            enum: [ REPARTICAO_SIMPLES, REPARTICAO_CAPITAIS_COBERTURA, CAPITALIZACAO ]
           reclaim:
             $ref: '#/components/schemas/PensionPlanReclaim'
           otherGuarateedValues:
             type: string
             description: Outros valores garantidos.
-            example: Saldamento
-            enum: [SALDAMENTO, BENEFICIO_PROLOGANDO, NAO_APLICA]
+            example: SALDAMENTO
+            enum: [ SALDAMENTO, BENEFICIO_PROLOGANDO, NAO_APLICA ]
           profitModality:
             type: string
             description: Modalidade de pagamento da indenização.
-            enum: [PAGAMENTO_UNICO, FORMA_RENDA]
+            enum: [ PAGAMENTO_UNICO, FORMA_RENDA ]
           contributionPayment:
             $ref: '#/components/schemas/PensionPlanContributionPayment'
           contributionTax:
@@ -290,15 +294,15 @@ components:
             $ref: '#/components/schemas/PensionPlanMinimumRequirements'
           targetAudience:
             type: string
-            example: Pessoa Natural
-            enum: [PESSOA_NATURAL, PESSOA_JURIDICA]           
+            example: PESSOA_NATURAL
+            enum: [ PESSOA_NATURAL, PESSOA_JURIDICA ]
     PensionPlanTerms:
       type: object
       description: Informações dos termos e condições conforme número do processo SUSEP.
       required:
         - susepProcessNumber
         - definition
-      properties:  
+      properties:
         susepProcessNumber:
           type: string
           description: Número do processo SUSEP.
@@ -313,77 +317,72 @@ components:
         - code
         - description
       properties:
-        code: 
+        code:
           type: string
-          description: Tipo unidade de medida 
+          description: Tipo unidade de medida
         description:
           type: string
           description: Descrição da unidade de medida
     PensionPlanCovaregeAttibutesDetails:
-        type: object
-        required:
-          - amount
-          - unit
-        properties:
-          amount:
-            type: number
-          unit:
-            $ref: '#/components/schemas/PensionPlanCovaregeAttibutesDetailsUnit'
+      type: object
+      required:
+        - amount
+        - unit
+      properties:
+        amount:
+          type: number
+        unit:
+          $ref: '#/components/schemas/PensionPlanCovaregeAttibutesDetailsUnit'
     PensionPlanCoverageAttributes:
       type: object
       description: Atributos da cobertura.
       required:
-       - indenizationPaymentMethod
-       - indenizationPaymentFrequency
-       - minValue
-       - maxValue
-       - indemnifiablePeriod
-       - indemnifiableDeadline
-       - currency
-       - gracePeriod
-       - excludedRisk
-       - excludedRiskURL
+        - indenizationPaymentMethod
+        #- indenizationPaymentFrequency
+        - minValue
+        - maxValue
+        - indemnifiablePeriod
+        - indemnifiableDeadline
+        - currency
+        - gracePeriod
+        - excludedRisk
+        - excludedRiskURL
       properties:
         indenizationPaymentMethod:
           type: string
           description: Forma de pagamento da indenização.
-          example: Pagamento Único
-          enum: [PAGAMENTO_UNICO, FORMA_RENDA]
+          example: PAGAMENTO_UNICO
+          enum: [ PAGAMENTO_UNICO, FORMA_RENDA ]
         minValue:
-          description: Valor mínimo de cobertura diária ou parcelada. Em reais.
-          example: 14
           $ref: '#/components/schemas/PensionPlanCovaregeAttibutesDetails'
         maxValue:
-          description: Valor máxima de cobertura diária ou parcelada. Em reais.
-          example: 14
           $ref: '#/components/schemas/PensionPlanCovaregeAttibutesDetails'
         indemnifiablePeriod:
           type: string
           description: Período indenizável. Se for indenização única, esse campo não se aplica.
-          example: Prazo
-          enum: [PRAZO, ATE_FIM_CICLO_DETERMINADO]
+          example: PRAZO
+          enum: [ PRAZO, ATE_FIM_CICLO_DETERMINADO ]
         indemnifiableDeadline:
           type: integer
-          description: Número máximo de parcelas indenizáveis. Caso seja relacionado a parcelas. 
+          description: Número máximo de parcelas indenizáveis. Caso seja relacionado a parcelas.
           example: 48
         currency:
           type: string
           description: Moeda utilizada.
           example: BRL
-          enum: [AFN, ALL, DZD, USD, EUR, AOA, XCD, XCD, ARS, AMD, AWG, AUD, EUR, AZN, BSD, BHD, BDT, BBD, BYN, EUR, BZD, XOF, BMD, BTN, BOB, BOV, USD, BAM, BWP, NOK, BRL, USD, BND, BGN, XOF, BIF, CVE, KHR, XAF, CAD, KYD, XAF, XAF, CLF, CLP, CNY, AUD, AUD, COP, COU, KMF, CDF, XAF, NZD, CRC, HRK, CUC, CUP, ANG, EUR, CZK, XOF, DKK, DJF, XCD, DOP, USD, EGP, SVC, USD, XAF, ERN, EUR, ETB, EUR, FKP, DKK, FJD, EUR, EUR, EUR, XPF, EUR, XAF, GMD, GEL, EUR, GHS, GIP, EUR, DKK, XCD, EUR, USD, GTQ, GBP, GNF, XOF, GYD, HTG, USD, AUD, EUR, HNL, HKD, HUF, ISK, INR, IDR, XDR, IRR, IQD, EUR, GBP, ILS, EUR, JMD, JPY, GBP, JOD, KZT, KES, AUD, KPW, KRW, KWD, KGS, LAK, EUR, LBP, LSL, ZAR, LRD, LYD, CHF, EUR, EUR, MOP, MGA, MWK, MYR, MVR, XOF, EUR, USD, EUR, MRU, MUR, EUR, XUA, MXN, MXV, USD, MDL, EUR, MNT, EUR, XCD, MAD, MZN, MMK, NAD, ZAR, AUD, NPR, EUR, XPF, NZD, NIO, XOF, NGN, NZD, AUD, USD, NOK, OMR, PKR, USD, PAB, USD, PGK, PYG, PEN, PHP, NZD, PLN, EUR, USD, QAR, MKD, RON, RUB, RWF, EUR, EUR, SHP, XCD, XCD, EUR, EUR, XCD, WST, EUR, STN, SAR, XOF, RSD, SCR, SLL, SGD, ANG, XSU, EUR, EUR, SBD, SOS, ZAR, SSP, EUR, LKR, SDG, SRD, NOK, SZL, SEK, CHE, CHF, CHW, SYP, TWD, TJS, TZS, THB, USD, XOF, NZD, TOP, TTD, TND, TRY, TMT, USD, AUD, UGX, UAH, AED, GBP, USD, USD, USN, UYI, UYU, UZS, VUV, VEF, VND, USD, USD, XPF, MAD, YER, ZMW, ZWL, EUR]
+          enum: [ AFN, ALL, DZD, USD, EUR, AOA, XCD, ARS, AMD, AWG, AUD, AZN, BSD, BHD, BDT, BBD, BYN, BZD, XOF, BMD, BTN, BOB, BOV, BAM, BWP, NOK, BRL, BND, BGN, BIF, CVE, KHR, XAF, CAD, KYD, CLF, CLP, CNY, COP, COU, KMF, CDF, NZD, CRC, HRK, CUC, CUP, ANG, CZK, DKK, DJF, DOP, EGP, SVC, ERN, ETB, FKP, FJD, XPF, GMD, GEL, GHS, GIP, GTQ, GBP, GNF, GYD, HTG, HNL, HKD, HUF, ISK, INR, IDR, XDR, IRR, IQD, ILS, JMD, JPY, JOD, KZT, KES, KPW, KRW, KWD, KGS, LAK, LBP, LSL, ZAR, LRD, LYD, CHF, MOP, MGA, MWK, MYR, MVR, MRU, MUR, XUA, MXN, MXV, MDL, MNT, MAD, MZN, MMK, NAD, NPR, NIO, NGN, OMR, PKR, PAB, PGK, PYG, PEN, PHP, PLN, QAR, MKD, RON, RUB, RWF, SHP, WST, STN, SAR, RSD, SCR, SLL, SGD, XSU, SBD, SOS, SSP, LKR, SDG, SRD, SZL, SEK, CHE, CHW, SYP, TWD, TJS, TZS, THB, TOP, TTD, TND, TRY, TMT, UGX, UAH, AED, USN, UYI, UYU, UZS, VUV, VEF, VND, YER, ZMW, ZWL ]
         gracePeriod:
           $ref: '#/components/schemas/PensionPlanGracePeriod'
-          description: Período de carência.
         excludedRisk:
           type: array
           description: Riscos excluídos.
           items:
             type: string
-            enum: [ATO_RECONHECIMENTO_PERIGOSO, ATO_ILICITO_DOLOSO_PRATICADO_SEGURADO, OPERACOES_DE_GUERRA, FURACOES_CICLONES_TERREMOTOS, MATERIAL_NUCLEAR, DOENCAS_LESOES_PREEXISTENTES, EPIDEMIAS_PANDEMIAS, SUICIDIO, ATO_ILICITO_DOLOSO_PRATICADO_CONTROLADOR, OUTROS]
+            enum: [ ATO_RECONHECIMENTO_PERIGOSO, ATO_ILICITO_DOLOSO_PRATICADO_SEGURADO, OPERACOES_DE_GUERRA, FURACOES_CICLONES_TERREMOTOS, MATERIAL_NUCLEAR, DOENCAS_LESOES_PREEXISTENTES, EPIDEMIAS_PANDEMIAS, SUICIDIO, ATO_ILICITO_DOLOSO_PRATICADO_CONTROLADOR, OUTROS ]
         excludedRiskURL:
           type: string
-          description: Campo aberto (possibilidade de incluir URL) 
-    PensionPlanUpdatePMBaC:     
+          description: Campo aberto (possibilidade de incluir URL)
+    PensionPlanUpdatePMBaC:
       type: object
       description: Atualização/ Remuneração da PMaC.
       required:
@@ -397,9 +396,9 @@ components:
         updateIndex:
           type: string
           description: Índice utilizado na atualização da PMBaC.
-          example: IPCA(IBGE)
-          enum: [FINANCEIRA, IGPM, INPC]
-    PensionPlanAgeReframing:     
+          example: PRAZO
+          enum: [ PRAZO, IGPM, INPC ]
+    PensionPlanAgeReframing:
       type: object
       description: Reenquadramento etário.
       required:
@@ -409,13 +408,13 @@ components:
         reframingCriterion:
           type: string
           description: Critério para reenquadramento etário.
-          example: Após período em anos
-          enum: [APOS_PERIODO_ANOS, CADA_PERIODO_ANOS, MUDANCA_FAIXA_ETARIA, NAO_APLICAVEL]      
+          example: APOS_PERIODO_ANOS
+          enum: [ APOS_PERIODO_ANOS, CADA_PERIODO_ANOS, MUDANCA_FAIXA_ETARIA, NAO_APLICAVEL ]
         reframingPeriodicity:
           type: integer
           description: Período em anos para reenquadramento etário.
           example: 10
-    PensionPlanReclaim:     
+    PensionPlanReclaim:
       type: object
       description: Resgate.
       required:
@@ -427,21 +426,21 @@ components:
           description: Percentual de resgate para PMBaC para cada conjunto aplicável.
           items:
             $ref: '#/components/schemas/PensionPlanReclaimTable'
-        differentiatedPercentage: 
+        differentiatedPercentage:
           type: string
           description: Campo aberto (possibilidade de incluir URL)
         gracePeriod:
           type: string
           description: Prazo de carência em dias para resgate.
           example: 20/Não se aplica
-    PensionPlanReclaimTable: 
+    PensionPlanReclaimTable:
       type: object
-      required: 
+      required:
         - initialMonthRange
         - finalMonthRange
         - percentage
-      properties: 
-        initialMonthRange: 
+      properties:
+        initialMonthRange:
           type: number
           description: Mês inicial do range
         finalMonthRange:
@@ -450,7 +449,7 @@ components:
         percentage:
           type: string
           description: Percentual da faixa de resgate
-    PensionPlanContributionPayment:     
+    PensionPlanContributionPayment:
       type: object
       description: Pagamento da contribuição.
       required:
@@ -462,15 +461,15 @@ components:
           description: Forma de pagamento da contribuição.
           items:
             type: string
-            example: Cartão de crédito            
-            enum: [CARTAO_CREDITO, DEBITO_CONTA, DEBITO_CONTA_POUPANCA, BOLETO_BANCARIO, PIX, TED_DOC, CONSIGNACAO_FOLHA_PAGAMENTO, PONTOS_PROGRAMA_BENEFICIO, OUTROS]      
+            example: CARTAO_CREDITO
+            enum: [ CARTAO_CREDITO, DEBITO_CONTA, DEBITO_CONTA_POUPANCA, BOLETO_BANCARIO, PIX, TED_DOC, CONSIGNACAO_FOLHA_PAGAMENTO, PONTOS_PROGRAMA_BENEFICIO, OUTROS ]
         contributionPeriodicity:
           type: array
           description: Periodicidade de pagamento da contribuição.
           items:
             type: string
-            example: Mensal
-            enum: [MENSAL, UNICA, ANUAL, TRIMESTRAL, SEMESTRAL, BIMESTRAL, OUTRAS]
+            example: MENSAL
+            enum: [ MENSAL, UNICA, ANUAL, TRIMESTRAL, SEMESTRAL, BIMESTRAL, OUTRAS ]
     PensionPlanMinimumRequirements:
       type: object
       description: Requisitos mínimos.
@@ -481,25 +480,25 @@ components:
         minRequirementsContractType:
           type: string
           description: Tipo de contratação.
-          example: Individual
-          enum: [COLETIVO, INDIVIDUAL]
+          example: COLETIVO
+          enum: [ COLETIVO, INDIVIDUAL ]
         minRequirementsContract:
           type: string
           description: Campo aberto contendo todos os requisitos mínimos para contratação.
           example: wwww.seguradora.com.br/termos
     PensionPlanGracePeriod:
       type: object
-      properties: 
+      properties:
         amount:
           type: number
           description: Prazo de Carência
         unit:
           type: string
           description: Unidade do prazo (dias ou meses)
-          enum: [DIAS, MESES, NAO_SE_APLICA]
+          enum: [ DIAS, MESES, NAO_SE_APLICA ]
     LinksPaginated:
       type: object
-      required: 
+      required:
         - self
       properties:
         self:
@@ -570,13 +569,13 @@ components:
                 description: 'Data e hora da consulta, conforme especificação RFC-3339, formato UTC.'
                 type: string
                 pattern: '[\w\W\s]*'
-                maxLength: 2048  
+                maxLength: 2048
                 format: date-time
                 example: '2021-08-20T08:30:00Z'
             additionalProperties: false
         meta:
           $ref: '#/components/schemas/MetaPaginated'
-      additionalProperties: false    
+      additionalProperties: false
   parameters:
     page:
       name: page
@@ -593,7 +592,7 @@ components:
       schema:
         type: integer
         default: 10
-        minimum: 1  
+        minimum: 1
     cnpjNumber:
       name: cnpjNumber
       in: path
@@ -606,7 +605,7 @@ components:
       in: header
       description: Controle de cache para evitar que informações confidenciais sejam armazenadas em cache.
       required: true
-      schema: 
+      schema:
         type: string
         pattern: '[\w\W\s]*'
     content-Security-Policy:
@@ -629,16 +628,16 @@ components:
       description: Campo para exigir conexões por HTTPS e proteger contra certificados falsificados.
       schema:
         type: string
-        pattern:  '[\w\W\s]*'
+        pattern: '[\w\W\s]*'
     x-Content-Type-Options:
-      name: X-Content-Type-Options
+      name: x-Content-Type-Options
       in: header
       description: Campo para evitar que navegadores executem a detecção de MIME e interpretem respostas como HTML de forma inadequada.
       schema:
         type: string
         pattern: '[\w\W\s]*'
     x-Frame-Options:
-      name: X-Frame-Options
+      name: x-Frame-Options
       in: header
       description: Campo indica se o navegador deve ou não renderizar um frame.
       schema:
@@ -656,9 +655,9 @@ components:
           authorizationUrl: 'https://authserver.example/authorization'
           tokenUrl: 'https://authserver.example/token'
           scopes:
-            financings: Escopo necessário para acesso à API. O controle dos endpoints específicos é feito via permissions.    
+            financings: Escopo necessário para acesso à API. O controle dos endpoints específicos é feito via permissions.
   responses:
-    Created: 
+    Created:
       description: 'A operação resulta na criação de um novo recurso.'
     NoContent:
       description: ''
@@ -721,5 +720,4 @@ components:
       content:
         application/json; charset=utf-8:
           schema:
-            $ref: '#/components/schemas/ResponseError'          
-  
+            $ref: '#/components/schemas/ResponseError'

--- a/documentation/source/files/swagger/pension-plan.yaml
+++ b/documentation/source/files/swagger/pension-plan.yaml
@@ -26,8 +26,8 @@ paths:
         - $ref: '#/components/parameters/content-Security-Policy'
         - $ref: '#/components/parameters/content-Type'
         - $ref: '#/components/parameters/strict-Transport-Security'
-        - $ref: '#/components/parameters/x-Content-Type-Options'
-        - $ref: '#/components/parameters/x-Frame-Options'
+        - $ref: '#/components/parameters/xxx-Content-Type-Options'
+        - $ref: '#/components/parameters/xxx-Frame-Options'
         - $ref: '#/components/parameters/page'
         - $ref: '#/components/parameters/pageSize'
       responses:
@@ -622,15 +622,15 @@ components:
       schema:
         type: string
         pattern: '[\w\W\s]*'
-    x-Content-Type-Options:
-      name: x-Content-Type-Options
+    xxx-Content-Type-Options:
+      name: xxx-Content-Type-Options
       in: header
       description: Campo para evitar que navegadores executem a detecção de MIME e interpretem respostas como HTML de forma inadequada.
       schema:
         type: string
         pattern: '[\w\W\s]*'
-    x-Frame-Options:
-      name: x-Frame-Options
+    xxx-Frame-Options:
+      name: xxx-Frame-Options
       in: header
       description: Campo indica se o navegador deve ou não renderizar um frame.
       schema:

--- a/documentation/source/files/swagger/pension-plan.yaml
+++ b/documentation/source/files/swagger/pension-plan.yaml
@@ -82,8 +82,8 @@ components:
       required:
         - data
         - brand
-        - linksPaginated
-        - metaPaginated
+        - links
+        - meta
       properties:
         requestTime:
           description: 'Data e hora da consulta, conforme especificação RFC-3339, formato UTC.'
@@ -96,9 +96,9 @@ components:
           type: object
         brand:
           $ref: '#/components/schemas/PensionPlanBrand'
-        linksPaginated:
+        links:
           $ref: '#/components/schemas/LinksPaginated'
-        metaPaginated:
+        meta:
           $ref: '#/components/schemas/MetaPaginated'
     PensionPlanBrand:
       type: object

--- a/documentation/source/files/swagger/person.yaml
+++ b/documentation/source/files/swagger/person.yaml
@@ -14,7 +14,7 @@ servers:
 tags:
   - name: 'person'
 paths:
-  /person/:
+  /person:
     get:
       tags:
         - person
@@ -395,19 +395,6 @@ components:
           description: Unidade do prazo (dias ou meses).
           example: DIAS
           enum: [ DIAS, MESES, NAO_SE_APLICA ]
-    personPortabilityGraceTime:
-      type: object
-      description: Prazo de carência em dias para Portabilidade
-      properties:
-        amount:
-          type: number
-          description: Prazo de Carência
-          example: 60
-        unit:
-          type: string
-          description: Unidade do prazo (dias ou meses).
-          example: DIAS
-          enum: [ DIAS, MESES, NAO_SE_APLICA ]
     PersonCoverageAttributes:
       type: object
       required:
@@ -699,13 +686,6 @@ components:
         type: integer
         default: 10
         minimum: 1
-    cnpjNumber:
-      name: cnpjNumber
-      in: path
-      description: Número de CNPJ.
-      required: true
-      schema:
-        type: string
     cache-Control:
       name: cache-control
       in: header

--- a/documentation/source/files/swagger/person.yaml
+++ b/documentation/source/files/swagger/person.yaml
@@ -26,8 +26,8 @@ paths:
         - $ref: '#/components/parameters/content-Security-Policy'
         - $ref: '#/components/parameters/content-Type'
         - $ref: '#/components/parameters/strict-Transport-Security'
-        - $ref: '#/components/parameters/x-Content-Type-Options'
-        - $ref: '#/components/parameters/x-Frame-Options'
+        - $ref: '#/components/parameters/xxx-Content-Type-Options'
+        - $ref: '#/components/parameters/xxx-Frame-Options'
         - $ref: '#/components/parameters/page'
         - $ref: '#/components/parameters/pageSize'
       responses:
@@ -715,15 +715,15 @@ components:
       schema:
         type: string
         pattern: '[\w\W\s]*'
-    x-Content-Type-Options:
-      name: x-Content-Type-Options
+    xxx-Content-Type-Options:
+      name: xxx-Content-Type-Options
       in: header
       description: Campo para evitar que navegadores executem a detecção de MIME e interpretem respostas como HTML de forma inadequada.
       schema:
         type: string
         pattern: '[\w\W\s]*'
-    x-Frame-Options:
-      name: x-Frame-Options
+    xxx-Frame-Options:
+      name: xxx-Frame-Options
       in: header
       description: Campo indica se o navegador deve ou não renderizar um frame.
       schema:

--- a/documentation/source/files/swagger/person.yaml
+++ b/documentation/source/files/swagger/person.yaml
@@ -1,35 +1,35 @@
 openapi: 3.0.0
 info:
   title: APIs Open Data do Open Insurance Brasil
-  description: 
+  description:
     Obtém a lista dos produtos Seguros de Pessoas – Coberturas de Risco (excluindo VGBL).
   version: 1.0.0
   contact:
-    url: 'https://http://novosite.susep.gov.br'
+    url: 'https://novosite.susep.gov.br'
 servers:
   - url: 'https://api.organizacao.com.br/open-insurance/products-services/v1'
     description: Servidor de Produção
   - url: 'https://api.organizacao.com.br/open-insurance/products-services/v1'
-    description: Servidor de Homologação  
+    description: Servidor de Homologação
 tags:
-- name: "person"
+  - name: 'person'
 paths:
   /person/:
     get:
       tags:
         - person
-      summary: Obtém a lista dos produtos do tipo seguro de pessoas. 
-      description: "Obtém a lista dos produtos do tipo seguro de pessoas."
-      operationId: "getPerson"
+      summary: Obtém a lista dos produtos do tipo seguro de pessoas.
+      description: 'Obtém a lista dos produtos do tipo seguro de pessoas.'
+      operationId: 'getPerson'
       parameters:
-        - $ref: "#/components/parameters/cache-Control"
-        - $ref: "#/components/parameters/content-Security-Policy"
-        - $ref: "#/components/parameters/content-Type"
-        - $ref: "#/components/parameters/strict-Transport-Security"
-        - $ref: "#/components/parameters/x-Content-Type-Options"
-        - $ref: "#/components/parameters/x-Frame-Options"
-        - $ref: "#/components/parameters/page"
-        - $ref: "#/components/parameters/pageSize"
+        - $ref: '#/components/parameters/cache-Control'
+        - $ref: '#/components/parameters/content-Security-Policy'
+        - $ref: '#/components/parameters/content-Type'
+        - $ref: '#/components/parameters/strict-Transport-Security'
+        - $ref: '#/components/parameters/x-Content-Type-Options'
+        - $ref: '#/components/parameters/x-Frame-Options'
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
       responses:
         '200':
           description: Dados dos Plano de Seguro de Pessoas
@@ -54,27 +54,31 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
         default:
-          $ref: '#/components/schemas/ResponsePersonList'               
+          description: Resposta
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponsePersonList'
 components:
   schemas:
     ResponsePersonList:
       type: object
       required:
-       - data
-       - links
-       - meta
+        - data
+        - links
+        - meta
       properties:
-       data: 
-        type: object
-        required:
-          - brand
-        properties:
-          brand:
-            $ref: '#/components/schemas/PersonBrand'
-       links:
-         $ref: '#/components/schemas/LinksPaginated'
-       meta:
-         $ref: '#/components/schemas/MetaPaginated'
+        data:
+          type: object
+          required:
+            - brand
+          properties:
+            brand:
+              $ref: '#/components/schemas/PersonBrand'
+        links:
+          $ref: '#/components/schemas/LinksPaginated'
+        meta:
+          $ref: '#/components/schemas/MetaPaginated'
     PersonBrand:
       type: object
       description: Organização controladora do grupo.
@@ -87,7 +91,7 @@ components:
           description: Nome da marca reportada pelo participante do Open Insurance. O conceito a que se refere a marca é em essência uma promessa das sociedades sob ela em fornecer uma série específica de atributos, benefícios e serviços uniformes aos clientes.
           example: Marca
         companies:
-            $ref: '#/components/schemas/PersonCompany'  
+          $ref: '#/components/schemas/PersonCompany'
     PersonCompany:
       type: array
       items:
@@ -95,7 +99,7 @@ components:
         required:
           - name
           - cnpjNumber
-          - product
+          - products
         properties:
           name:
             type: string
@@ -104,8 +108,8 @@ components:
           cnpjNumber:
             type: string
             description: CNPJ da sociedade pertencente à marca.
-            example: 45086338000178
-          products:          
+            example: '45086338000178'
+          products:
             $ref: '#/components/schemas/PersonProducts'
     PersonProducts:
       type: array
@@ -116,7 +120,7 @@ components:
           - name
           - code
           - category
-          - insuranceModality 
+          - insuranceModality
           - coverages
           - additional
           - termsAndConditions
@@ -141,11 +145,11 @@ components:
           category:
             type: string
             description: Indica a categoria do Produto
-            enum: [TRADICIONAL, MICROSEGURO]
+            enum: [ TRADICIONAL, MICROSEGURO ]
           insuranceModality:
             type: string
             example: FUNERAL
-            enum: [FUNERAL, PRESTAMISTA, VIAGEM, EDUCACIONAL, DOTAL, ACIDENTES_PESSOAIS, VIDA, PERDA_CERTIFICADO_HABILITACAOO_VOO, DOENCAS_GRAVES_DOENCA_TERMINAL, DESEMPREGO_PERDA_RENDA, EVENTOS_ALEATORIOS] 
+            enum: [ FUNERAL, PRESTAMISTA, VIAGEM, EDUCACIONAL, DOTAL, ACIDENTES_PESSOAIS, VIDA, PERDA_CERTIFICADO_HABILITACAOO_VOO, DOENCAS_GRAVES_DOENCA_TERMINAL, DESEMPREGO_PERDA_RENDA, EVENTOS_ALEATORIOS ]
           coverages:
             type: array
             items:
@@ -154,136 +158,136 @@ components:
                 coverage:
                   type: string
                   example: AUXILIO_CESTA_BASICA
-                  enum: [ADIANTAMENTO_DOENCA_ESTAGIO_TERMINAL,
-                        AUXILIO_CESTA_BASICA,
-                        AUXILIO_FINANCEIRO_IMEDIATO,
-                        CANCELAMENTO_DE_VIAGEM,
-                        CIRURGIA,
-                        COBERTURA_PARA_HERNIA,
-                        COBERTURA_PARA_LER_DORT,
-                        CUIDADOS_PROLONGADOS_ACIDENTE,
-                        DESEMPREGO_PERDA_DE_RENDA,
-                        DESPESAS_EXTRA_INVALIDEZ_PERMANENTE_TOTAL_PARCIAL_ACIDENTE_DEI,
-                        DESPESAS_EXTRA_MORTE_DEM,
-                        DESPESAS_MEDICAS_HOSPITALARES_ODONTOLOGICAS,
-                        DESPESAS_MEDICAS_HOSPITALARES_ODONTOLOGICAS_BRASIL,
-                        DESPESAS_MEDICAS_HOSPITALARES_ODONTOLOGICAS_EXTERIOR,
-                        DIARIA_INCAPACIDADE_TOTAL_TEMPORARIA,
-                        DIARIA_INTERNACAO_HOSPITALAR,
-                        INTERNACAO_HOSPITALAR,
-                        DIARIAS_INCAPACIDADE_PECUNIARIA_DIP,
-                        DOENCA_GRAVE,
-                        DOENCA_CONGENITA_FILHOS_DCF,
-                        FRATURA_OSSEA,
-                        DOENCAS_TROPICAIS,
-                        INCAPACIDADE_TOTAL_OU_TEMPORARIA,
-                        INVALIDEZ_PERMANENTE_TOTAL_PARCIAL,
-                        INVALIDEZ_TOTAL_ACIDENTE,
-                        INVALIDEZ_PARCIAL_ACIDENTE,
-                        INVALIDEZ_FUNCIONAL_PERMANENTE_DOENCA,
-                        INVALIDEZ_LABORATIVA_DOENCA,
-                        MORTE,
-                        MORTE_ACIDENTAL,
-                        MORTE_CONJUGE,
-                        MORTE_FILHOS,
-                        MORTE_ADIATAMENTO_DOENCA_ESTAGIO_TERMINAL,
-                        PAGAMENTO_ANTECIPADO_ESPECIAL_DOENCA_PROFISSIONAL_PAED,
-                        PERDA_DA_AUTONOMIA_PESSOAL,
-                        PERDA_INVOLUNTARIA_EMPREGO,
-                        QUEIMADURA_GRAVE,
-                        REGRESSO_ANTECIPADO_SANITARIO,
-                        RENDA_INCAPACIDADE_TEMPORARIA,
-                        RESCISAO_CONTRATUAL_CASO_MORTE_RCM,
-                        RESCISAO_TRABALHISTA,
-                        SERVICO_AUXILIO_FUNERAL,
-                        SOBREVIVENCIA,
-                        TRANSPLANTE_ORGAOS,
-                        TRANSLADO,
-                        TRANSLADO_MEDICO,
-                        TRANSLADO_CORPO,
-                        VERBA_RESCISORIA,
-                        OUTRAS]                
+                  enum: [ ADIANTAMENTO_DOENCA_ESTAGIO_TERMINAL,
+                          AUXILIO_CESTA_BASICA,
+                          AUXILIO_FINANCEIRO_IMEDIATO,
+                          CANCELAMENTO_DE_VIAGEM,
+                          CIRURGIA,
+                          COBERTURA_PARA_HERNIA,
+                          COBERTURA_PARA_LER_DORT,
+                          CUIDADOS_PROLONGADOS_ACIDENTE,
+                          DESEMPREGO_PERDA_DE_RENDA,
+                          DESPESAS_EXTRA_INVALIDEZ_PERMANENTE_TOTAL_PARCIAL_ACIDENTE_DEI,
+                          DESPESAS_EXTRA_MORTE_DEM,
+                          DESPESAS_MEDICAS_HOSPITALARES_ODONTOLOGICAS,
+                          DESPESAS_MEDICAS_HOSPITALARES_ODONTOLOGICAS_BRASIL,
+                          DESPESAS_MEDICAS_HOSPITALARES_ODONTOLOGICAS_EXTERIOR,
+                          DIARIA_INCAPACIDADE_TOTAL_TEMPORARIA,
+                          DIARIA_INTERNACAO_HOSPITALAR,
+                          INTERNACAO_HOSPITALAR,
+                          DIARIAS_INCAPACIDADE_PECUNIARIA_DIP,
+                          DOENCA_GRAVE,
+                          DOENCA_CONGENITA_FILHOS_DCF,
+                          FRATURA_OSSEA,
+                          DOENCAS_TROPICAIS,
+                          INCAPACIDADE_TOTAL_OU_TEMPORARIA,
+                          INVALIDEZ_PERMANENTE_TOTAL_PARCIAL,
+                          INVALIDEZ_TOTAL_ACIDENTE,
+                          INVALIDEZ_PARCIAL_ACIDENTE,
+                          INVALIDEZ_FUNCIONAL_PERMANENTE_DOENCA,
+                          INVALIDEZ_LABORATIVA_DOENCA,
+                          MORTE,
+                          MORTE_ACIDENTAL,
+                          MORTE_CONJUGE,
+                          MORTE_FILHOS,
+                          MORTE_ADIATAMENTO_DOENCA_ESTAGIO_TERMINAL,
+                          PAGAMENTO_ANTECIPADO_ESPECIAL_DOENCA_PROFISSIONAL_PAED,
+                          PERDA_DA_AUTONOMIA_PESSOAL,
+                          PERDA_INVOLUNTARIA_EMPREGO,
+                          QUEIMADURA_GRAVE,
+                          REGRESSO_ANTECIPADO_SANITARIO,
+                          RENDA_INCAPACIDADE_TEMPORARIA,
+                          RESCISAO_CONTRATUAL_CASO_MORTE_RCM,
+                          RESCISAO_TRABALHISTA,
+                          SERVICO_AUXILIO_FUNERAL,
+                          SOBREVIVENCIA,
+                          TRANSPLANTE_ORGAOS,
+                          TRANSLADO,
+                          TRANSLADO_MEDICO,
+                          TRANSLADO_CORPO,
+                          VERBA_RESCISORIA,
+                          OUTRAS ]
                 coverageOthers:
                   type: array
                   items:
                     type: string
                 coverageAttributes:
                   $ref: '#/components/schemas/PersonCoverageAttributes'
-          assistanceType:        
+          assistanceType:
             type: array
-            description: Listagem dos serviços de assistências complementares disponíveis vinculados ao produto. Deve ser padronizada na proposta técnica submetida pela Estrutura Inicial de  Governança para observância comum por todas as sociedades participantes 
-            items:  
+            description: Listagem dos serviços de assistências complementares disponíveis vinculados ao produto. Deve ser padronizada na proposta técnica submetida pela Estrutura Inicial de  Governança para observância comum por todas as sociedades participantes
+            items:
               type: string
-              enum: [ACOMPANHANTE_CASO_HOSPITALIZACAO_PROLONGADA,
-ARQUITETO_VIRTUAL,
-ASSESSORIA_FINANCEIRA,
-AUTOMOVEL,
-AUXILIO_NATALIDADE,
-AVALIACAO_CLINICA_PREVENTIVA,
-BOLSA_PROTEGIDA,
-CESTA_BASICA,
-CHECKUP_ODONTOLOGICO,
-CLUBE_VANTAGENS_BENEFICIOS,
-CONVALESCENCIA,
-DECESSO,
-DESCONTO_FARMACIAS_MEDICAMENTOS,
-DESPESAS_FARMACEUTICAS_VIAGEM,
-DIGITAL,
-EDUCACIONAL,
-EMPRESARIAL,
-ENCANADOR,
-ENTRETENIMENTO,
-EQUIPAMENTOS_MEDICOS,
-FIANCAS_DESPESAS_LEGAIS,
-FISIOTERAPIA,
-FUNERAL,
-HELP_LINE,
-HOSPEDAGEM_ACOMPANHANTE,
-INTERRUPCAO_VIAGEM,
-INVENTARIO,
-MAIS_EM_VIDA,
-MAMAE_BEBE,
-MEDICA_ACIDENTE_DOENCA,
-MOTOCICLETA,
-MULHER,
-NUTRICIONISTA,
-ODONTOLOGICA,
-ORIENTACAO_FITNESS,
-ORIENTACAO_JURIDICA,
-ORIENTACAO_NUTRICIONAL,
-PERSONAL_FITNESS,
-ORIENTACAO_PSICOSSOCIAL_FAMILIAR,
-PERDA_ROUBO_CARTAO,
-PET,
-PRORROGACAO_ESTADIA,
-PROTECAO_DADOS,
-RECOLOCACAO_PROFISSIONAL,
-REDE_DESCONTO_NUTRICIONAL,
-RESIDENCIAL,
-RETORNO_MENORES_SEGURADO,
-SAQUE_COACAO,
-SAUDE_BEM_ESTAR,
-SEGUNDA_OPINIAO_MEDICA,
-SENIOR,
-SUSTENTAVEL_DESCARTE_ECOLOGICO,
-TELEMEDICINA,
-VIAGEM,
-VITIMA,
-OUTROS]  
-          additional:         
+              enum: [ ACOMPANHANTE_CASO_HOSPITALIZACAO_PROLONGADA,
+                      ARQUITETO_VIRTUAL,
+                      ASSESSORIA_FINANCEIRA,
+                      AUTOMOVEL,
+                      AUXILIO_NATALIDADE,
+                      AVALIACAO_CLINICA_PREVENTIVA,
+                      BOLSA_PROTEGIDA,
+                      CESTA_BASICA,
+                      CHECKUP_ODONTOLOGICO,
+                      CLUBE_VANTAGENS_BENEFICIOS,
+                      CONVALESCENCIA,
+                      DECESSO,
+                      DESCONTO_FARMACIAS_MEDICAMENTOS,
+                      DESPESAS_FARMACEUTICAS_VIAGEM,
+                      DIGITAL,
+                      EDUCACIONAL,
+                      EMPRESARIAL,
+                      ENCANADOR,
+                      ENTRETENIMENTO,
+                      EQUIPAMENTOS_MEDICOS,
+                      FIANCAS_DESPESAS_LEGAIS,
+                      FISIOTERAPIA,
+                      FUNERAL,
+                      HELP_LINE,
+                      HOSPEDAGEM_ACOMPANHANTE,
+                      INTERRUPCAO_VIAGEM,
+                      INVENTARIO,
+                      MAIS_EM_VIDA,
+                      MAMAE_BEBE,
+                      MEDICA_ACIDENTE_DOENCA,
+                      MOTOCICLETA,
+                      MULHER,
+                      NUTRICIONISTA,
+                      ODONTOLOGICA,
+                      ORIENTACAO_FITNESS,
+                      ORIENTACAO_JURIDICA,
+                      ORIENTACAO_NUTRICIONAL,
+                      PERSONAL_FITNESS,
+                      ORIENTACAO_PSICOSSOCIAL_FAMILIAR,
+                      PERDA_ROUBO_CARTAO,
+                      PET,
+                      PRORROGACAO_ESTADIA,
+                      PROTECAO_DADOS,
+                      RECOLOCACAO_PROFISSIONAL,
+                      REDE_DESCONTO_NUTRICIONAL,
+                      RESIDENCIAL,
+                      RETORNO_MENORES_SEGURADO,
+                      SAQUE_COACAO,
+                      SAUDE_BEM_ESTAR,
+                      SEGUNDA_OPINIAO_MEDICA,
+                      SENIOR,
+                      SUSTENTAVEL_DESCARTE_ECOLOGICO,
+                      TELEMEDICINA,
+                      VIAGEM,
+                      VITIMA,
+                      OUTROS ]
+          additional:
             type: array
             items:
               type: string
-              enum: [SORTEIO , SERVICOS_ASSISTENCIAS_COMPLEMENTARES_PAGO , SERVICOS_ASSISTENCIA_COMPLEMENTARES_GRATUITO, OUTROS, NAO_HA] 
+              enum: [ SORTEIO , SERVICOS_ASSISTENCIAS_COMPLEMENTARES_PAGO , SERVICOS_ASSISTENCIA_COMPLEMENTARES_GRATUITO, OUTROS, NAO_HA ]
           assistanceTypeOthers:
             type: array
             items:
               type: string
-              description: Campo a ser preenchido pelas participantes quando houver ‘Outros’ no campo ‘Tipo de Assistência’   
+              description: Campo a ser preenchido pelas participantes quando houver ‘Outros’ no campo ‘Tipo de Assistência’
           termsAndConditions:
             type: array
             items:
-              $ref: '#/components/schemas/PersonTermsAndCondition' 
+              $ref: '#/components/schemas/PersonTermsAndCondition'
           globalCapital:
             type: boolean
             description: Seguro de pessoas com capital global modalidade de contratação coletiva da cobertura de risco, respeitados os critérios técnico-operacionais, forma e limites fixados pela SUSEP, segundo a qual o valor do capital segurado referente a cada componente sofrerá variações decorrentes de mudanças na composição do grupo segurado
@@ -291,7 +295,7 @@ OUTROS]
             type: array
             items:
               type: string
-              enum: [VITALICIA, TEMPORARIA_PRAZO_FIXO, TEMPORARIA_INTERMITENTE]  
+              enum: [ VITALICIA, TEMPORARIA_PRAZO_FIXO, TEMPORARIA_INTERMITENTE ]
           pmbacRemuneration:
             $ref: '#/components/schemas/PersonPmbacRemuneration'
           benefitRecalculation:
@@ -300,13 +304,13 @@ OUTROS]
             $ref: '#/components/schemas/PersonAgeAdjustment'
           contractType:
             type: string
-            description: Regime Financeiro  
-            enum: [REPARTICAO_SIMPLES, REPARTICAO_CAPITAIS, CAPITALIZACAO ] 
+            description: Regime Financeiro
+            enum: [ REPARTICAO_SIMPLES, REPARTICAO_CAPITAIS, CAPITALIZACAO ]
           reclaim:
             $ref: '#/components/schemas/PersonReclaim'
           otherGuaranteedValues:
             type: string
-            enum: [SALDAMENTO, BENEFICIO_PROLONGADO, NAO_SE_APLICA]
+            enum: [ SALDAMENTO, BENEFICIO_PROLONGADO, NAO_SE_APLICA ]
           allowPortability:
             type: boolean
             description: Permite Portabilidade
@@ -315,35 +319,35 @@ OUTROS]
             description: Prazo de carência em dias para Portabilidade
           indemnityPaymentMethod:
             type: array
-            items:  
+            items:
               type: string
               description: Modalidade de pagamento da indenização
-              enum: [UNICO, SOB_FORMA_DE_RENDA]  
+              enum: [ UNICO, SOB_FORMA_DE_RENDA ]
           indemnityPaymentIncome:
             type: array
             items:
               type: string
-              enum: [CERTA,
-TEMPORARIA,
-TEMPORARIA_REVERSIVEL,
-TEMPORARIO_MINIMO_GARANTIDO,
-TEMPORARIA_REVERSIVEL_MINIMO_GARANTIDO,
-VITALICIA,
-VITALICIA_REVERSIVEL,
-VITALICIA_MINIMO_GARANTIDO,
-VITALICIA_REVERSIVEL_MINIMO_GARANTIDO
-]
+              enum: [ CERTA,
+                      TEMPORARIA,
+                      TEMPORARIA_REVERSIVEL,
+                      TEMPORARIO_MINIMO_GARANTIDO,
+                      TEMPORARIA_REVERSIVEL_MINIMO_GARANTIDO,
+                      VITALICIA,
+                      VITALICIA_REVERSIVEL,
+                      VITALICIA_MINIMO_GARANTIDO,
+                      VITALICIA_REVERSIVEL_MINIMO_GARANTIDO
+              ]
           premiumPayment:
             $ref: '#/components/schemas/PersonPremiumPayment'
-          minimunRequirements:
-            $ref: '#/components/schemas/PersonMinimunRequirements'
+          minimumRequirements:
+            $ref: '#/components/schemas/PersonMinimumRequirements'
           targetAudience:
             type: string
-            enum: [PESSOA_NATURAL, PESSOA_JURIDICA]
-    PersonTermsAndCondition:     
+            enum: [ PESSOA_NATURAL, PESSOA_JURIDICA ]
+    PersonTermsAndCondition:
       type: object
       required:
-        - susepProcessNumber    
+        - susepProcessNumber
         - definition
       properties:
         susepProcessNumber:
@@ -358,100 +362,100 @@ VITALICIA_REVERSIVEL_MINIMO_GARANTIDO
         - code
         - description
       properties:
-        code: 
+        code:
           type: string
           description: Tipo unidade de medida.
           example: R$
-        description: 
+        description:
           type: string
           description: Descrição da unidade de medida
           example: description
     PersonCoverageAttibutesDetails:
-        type: object
-        required:
-          - amount
-          - unit
-        properties:
-          amount:
-            type: number
-            description: Valor.
-            example: 60
-          unit:
-            $ref: '#/components/schemas/PersonCoverageAttibutesDetailsUnit'
+      type: object
+      required:
+        - amount
+        - unit
+      properties:
+        amount:
+          type: number
+          description: Valor.
+          example: 60
+        unit:
+          $ref: '#/components/schemas/PersonCoverageAttibutesDetailsUnit'
     PersonGracePeriodUnit:
-        type: object
-        description: Período de carência
-        properties:
-          amount:
-            type: number
-            description: Prazo de Carência
-            example: 60
-          unit:
-            type: string
-            description: Unidade do prazo (dias ou meses).
-            example: DIAS
-            enum: [DIAS, MESES, NAO_SE_APLICA]
+      type: object
+      description: Período de carência
+      properties:
+        amount:
+          type: number
+          description: Prazo de Carência
+          example: 60
+        unit:
+          type: string
+          description: Unidade do prazo (dias ou meses).
+          example: DIAS
+          enum: [ DIAS, MESES, NAO_SE_APLICA ]
     personPortabilityGraceTime:
-        type: object
-        description: Prazo de carência em dias para Portabilidade
-        properties:
-          amount:
-            type: number
-            description: Prazo de Carência
-            example: 60
-          unit:
-            type: string
-            description: Unidade do prazo (dias ou meses).
-            example: DIAS
-            enum: [DIAS, MESES, NAO_SE_APLICA]
+      type: object
+      description: Prazo de carência em dias para Portabilidade
+      properties:
+        amount:
+          type: number
+          description: Prazo de Carência
+          example: 60
+        unit:
+          type: string
+          description: Unidade do prazo (dias ou meses).
+          example: DIAS
+          enum: [ DIAS, MESES, NAO_SE_APLICA ]
     PersonCoverageAttributes:
       type: object
       required:
-        - indemnityPaymentMethod    
+        - indemnityPaymentMethod
         - indemnityPaymentFrequency
         - minValue
         - maxValue
         - indemnifiablePeriod
         - maximumQtyIndemnifiableInstallments
         - currency
-        - gracePeriod  
-        - deductibleDays 
-        - deductibleBRL    
+        - gracePeriod
+        - deductibleDays
+        - deductibleBRL
         - excludedRisks
-        - coverageGroup      
+        #- coverageGroup
         - allowApartPurchase
-        - minCoverageGroupRequired
+        #- minCoverageGroupRequired
       properties:
         indemnityPaymentMethod:
-           type: array
-           description: Listagem da forma de pagamento da indenização para cada combinação de  modalidade/cobertura do produto
-           items:  
+          type: array
+          description: Listagem da forma de pagamento da indenização para cada combinação de  modalidade/cobertura do produto
+          items:
             type: string
             example: PAGAMENTO_CAPITAL_SEGURADO_VALOR_MONETARIO
-            enum: [PAGAMENTO_CAPITAL_SEGURADO_VALOR_MONETARIO, REEMBOLSO_DESPESAS, PRESTACAO_SERVICOS]
+            enum: [ PAGAMENTO_CAPITAL_SEGURADO_VALOR_MONETARIO, REEMBOLSO_DESPESAS, PRESTACAO_SERVICOS ]
         indemnityPaymentFrequency:
           type: array
-          description: Listagem de tipos de frequência de pagamento de indenização para cada combinação de modalidade/cobertura do produto 
+          description: Listagem de tipos de frequência de pagamento de indenização para cada combinação de modalidade/cobertura do produto
           items:
-           type: string
-           example: INDENIZACAO_UNICA
-           enum: [INDENIZACAO_UNICA, DIARIA_OU_PARCELA]
+            type: string
+            example: INDENIZACAO_UNICA
+            enum: [ INDENIZACAO_UNICA, DIARIA_OU_PARCELA ]
         minValue:
           type: object
           description: Listagem do valor mínimo de cobertura (Capital Segurado), diária ou parcela aceito pela  sociedade para cada  combinação de modalidade/cobertura do produto. Em reais
           items:
-           $ref: '#/components/schemas/PersonCoverageAttibutesDetails'
+            $ref: '#/components/schemas/PersonCoverageAttibutesDetails'
         maxValue:
           type: object
           description: Listagem do valor máximo de cobertura (Capital Segurado), diária ou parcela aceito  pela sociedade para cada  combinação de modalidade/cobertura do produto. Em reais
           items:
-           $ref: '#/components/schemas/PersonCoverageAttibutesDetails'
+            $ref: '#/components/schemas/PersonCoverageAttibutesDetails'
         indemnifiablePeriod:
           type: array
-          description: Listagem de período indenizável para cada combinação de modalidade/cobertura do produto 
+          description: Listagem de período indenizável para cada combinação de modalidade/cobertura do produto
           items:
-           type: string
-           example: ATE_FIM_CICLO_DETERMINADO
+            type: string
+            example: ATE_FIM_CICLO_DETERMINADO
         maximumQtyIndemnifiableInstallments:
           type: integer
           description: Caso o período indenizável seja relacionado a parcelas, listagem de número máximo de  parcelas indenizáveis para cada combinação de modalidade/ cobertura do produto
@@ -459,15 +463,14 @@ VITALICIA_REVERSIVEL_MINIMO_GARANTIDO
           type: string
           description: Moeda sobre a qual a cobertura se refere. De acordo com ISO-4217.
           example: BRL
-          enum: [AFN,ALL,DZD,USD,EUR,AOA,XCD,XCD,ARS,AMD,AWG,AUD,EUR,AZN,BSD,BHD,BDT,BBD,BYN,EUR,BZD,XOF,BMD,BTN,BOB,BOV,USD,BAM,BWP,NOK,BRL,USD,BND,BGN,XOF,BIF,CVE,KHR,XAF,CAD,KYD,XAF,XAF,CLF,CLP,CNY,AUD,AUD,COP,COU,KMF,CDF,XAF,NZD,CRC,HRK,CUC,CUP,ANG,EUR,CZK,XOF,DKK,DJF,XCD,DOP,USD,EGP,SVC,USD,XAF,ERN,EUR,ETB,EUR,FKP,DKK,FJD,EUR,EUR,EUR,XPF,EUR,XAF,GMD,GEL,EUR,GHS,GIP,EUR,DKK,XCD,EUR,USD,GTQ,GBP,GNF,XOF,GYD,HTG,USD,AUD,EUR,HNL,HKD,HUF,ISK,INR,IDR,XDR,IRR,IQD,EUR,GBP,ILS,EUR,JMD,JPY,GBP,JOD,KZT,KES,AUD,KPW,KRW,KWD,KGS,LAK,EUR,LBP,LSL,ZAR,LRD,LYD,CHF,EUR,EUR,MOP,MGA,MWK,MYR,MVR,XOF,EUR,USD,EUR,MRU,MUR,EUR,XUA,MXN,MXV,USD,MDL,EUR,MNT,EUR,XCD,MAD,MZN,MMK,NAD,ZAR,AUD,NPR,EUR,XPF,NZD,NIO,XOF,NGN,NZD,AUD,USD,NOK,OMR,PKR,USD,PAB,USD,PGK,PYG,PEN,PHP,NZD,PLN,EUR,USD,QAR,MKD,RON,RUB,RWF,EUR,EUR,SHP,XCD,XCD,EUR,EUR,XCD,WST,EUR,STN,SAR,XOF,RSD,SCR,SLL,SGD,ANG,XSU,EUR,EUR,SBD,SOS,ZAR,SSP,EUR,LKR,SDG,SRD,NOK,SZL,SEK,CHE,CHF,CHW,SYP,TWD,TJS,TZS,THB,USD,XOF,NZD,TOP,TTD,TND,TRY,TMT,USD,AUD,UGX,UAH,AED,GBP,USD,USD,USN,UYI,UYU,UZS,VUV,VEF,VND,USD,USD,XPF,MAD,YER,ZMW,ZWL]   
+          enum: [ AFN, ALL, DZD, USD, EUR, AOA, XCD, ARS, AMD, AWG, AUD, AZN, BSD, BHD, BDT, BBD, BYN, BZD, XOF, BMD, BTN, BOB, BOV, BAM, BWP, NOK, BRL, BND, BGN, BIF, CVE, KHR, XAF, CAD, KYD, CLF, CLP, CNY, COP, COU, KMF, CDF, NZD, CRC, HRK, CUC, CUP, ANG, CZK, DKK, DJF, DOP, EGP, SVC, ERN, ETB, FKP, FJD, XPF, GMD, GEL, GHS, GIP, GTQ, GBP, GNF, GYD, HTG, HNL, HKD, HUF, ISK, INR, IDR, XDR, IRR, IQD, ILS, JMD, JPY, JOD, KZT, KES, KPW, KRW, KWD, KGS, LAK, LBP, LSL, ZAR, LRD, LYD, CHF, MOP, MGA, MWK, MYR, MVR, MRU, MUR, XUA, MXN, MXV, MDL, MNT, MAD, MZN, MMK, NAD, NPR, NIO, NGN, OMR, PKR, PAB, PGK, PYG, PEN, PHP, PLN, QAR, MKD, RON, RUB, RWF, SHP, WST, STN, SAR, RSD, SCR, SLL, SGD, XSU, SBD, SOS, SSP, LKR, SDG, SRD, SZL, SEK, CHE, CHW, SYP, TWD, TJS, TZS, THB, TOP, TTD, TND, TRY, TMT, UGX, UAH, AED, USN, UYI, UYU, UZS, VUV, VEF, VND, YER, ZMW, ZWL ]
         gracePeriod:
           $ref: '#/components/schemas/PersonGracePeriodUnit'
         differentiatedGracePeriod:
           $ref: '#/components/schemas/PersonGracePeriodUnit'
-          description: Detalhamento do período de carência diferentes para cada cobertura que exista alguma especificidade. Caso a seguradora não tenha essa diferenciação, não retornará nada no campo
         deductibleDays:
           type: integer
-          description: Listagem de franquia em dias para cada combinação de modalidade/cobertura do produto.         
+          description: Listagem de franquia em dias para cada combinação de modalidade/cobertura do produto.
         differentiatedDeductibleDays:
           type: number
           description: Detalhamento da franquia em dias diferentes para cada cobertura que exista alguma especificidade. Caso a seguradora não tenha essa diferenciação, não retornará nada no campo.
@@ -481,19 +484,19 @@ VITALICIA_REVERSIVEL_MINIMO_GARANTIDO
           type: array
           description: Listagem dos tipos de riscos excluídos para cada combinação de modalidade/cobertura do produto. Deve ser padronizada na proposta técnica submetida pela Estrutura Inicial de Governança para observância comum por todas as sociedades participantes
           items:
-           type: string
-           enum: [ATO_RECONHECIMENTO_PERIGOSO, ATO_ILICITO_DOLOSO_PRATICADO_SEGURADO, OPERACOES_DE_GUERRA, FURACOES_CICLONES_TERREMOTOS, MATERIAL_NUCLEAR, DOENCAS_LESOES_PREEXISTENTES, EPIDEMIAS_PANDEMIAS, SUICIDIO, ATO_ILICITO_DOLOSO_PRATICADO_CONTROLADOR, OUTROS]
+            type: string
+            enum: [ ATO_RECONHECIMENTO_PERIGOSO, ATO_ILICITO_DOLOSO_PRATICADO_SEGURADO, OPERACOES_DE_GUERRA, FURACOES_CICLONES_TERREMOTOS, MATERIAL_NUCLEAR, DOENCAS_LESOES_PREEXISTENTES, EPIDEMIAS_PANDEMIAS, SUICIDIO, ATO_ILICITO_DOLOSO_PRATICADO_CONTROLADOR, OUTROS ]
         excludedRisksURL:
           type: string
-          description: Campo aberto (possibilidade de incluir URL).        
+          description: Campo aberto (possibilidade de incluir URL).
         allowApartPurchase:
           type: boolean
           description: Indicar se a cobertura pode ser contratada isoladamente ou não.
-          example: true      
+          example: true
     PersonPmbacRemuneration:
       type: object
       required:
-        -     
+        #-
         - pmbacUpdateIndex
       properties:
         interestRate:
@@ -503,7 +506,7 @@ VITALICIA_REVERSIVEL_MINIMO_GARANTIDO
           type: string
           description: Índice utilizado na atualização da PMBaC.
           example: IPCA
-          enum: [IPCA, IGP-M,INPC]          
+          enum: [ IPCA, IGP-M,INPC ]
     PersonBenefitRecalculation:
       type: object
       required:
@@ -513,11 +516,11 @@ VITALICIA_REVERSIVEL_MINIMO_GARANTIDO
         benefitRecalculationCriteria:
           type: string
           example: INDICE
-          enum: [INDICE, VINCULADO_SALDO_DEVEDOR, VARIAVEL_ACORDO_CRITERIO_ESPECIFICO]
+          enum: [ INDICE, VINCULADO_SALDO_DEVEDOR, VARIAVEL_ACORDO_CRITERIO_ESPECIFICO ]
         benefitUpdateIndex:
           type: string
-          description: Índice utilizado na atualização do prêmio/contribuição e do capital segurado/ benefício,  caso critério de atualização por meio de índice  
-          enum: [IPCA, IGP-M ,INPC]
+          description: Índice utilizado na atualização do prêmio/contribuição e do capital segurado/ benefício,  caso critério de atualização por meio de índice
+          enum: [ IPCA, IGP-M ,INPC ]
     PersonAgeAdjustment:
       type: object
       required:
@@ -528,7 +531,7 @@ VITALICIA_REVERSIVEL_MINIMO_GARANTIDO
           type: string
           description: Critério escolhido para reenquadramento etário
           example: APOS_PERIODO_EM_ANOS
-          enum: [APOS_PERIODO_EM_ANOS, A_CADA_PERIODO_EM_ANOS, POR_MUDANCA_DE_FAIXA_ETARIA, NAO_APLICAVEL]
+          enum: [ APOS_PERIODO_EM_ANOS, A_CADA_PERIODO_EM_ANOS, POR_MUDANCA_DE_FAIXA_ETARIA, NAO_APLICAVEL ]
         frequency:
           type: integer
           description: Período em anos, caso critério de reenquadramento após ou a cada período em anos.
@@ -558,10 +561,10 @@ VITALICIA_REVERSIVEL_MINIMO_GARANTIDO
         - gracePeriod
       properties:
         reclaimTable:
-         type: array
-         description: Listagem de percentuais de resgate da PMBaC para cada conjunto de prazo aplicável e para cada combinação de modalidade/cobertura estruturados em regime de capitalização
-         items:
-          $ref: '#/components/schemas/personReclaimTable'
+          type: array
+          description: Listagem de percentuais de resgate da PMBaC para cada conjunto de prazo aplicável e para cada combinação de modalidade/cobertura estruturados em regime de capitalização
+          items:
+            $ref: '#/components/schemas/personReclaimTable'
         differentiatedPercentage:
           type: string
           description: Campo aberto (possibilidade de incluir URL).
@@ -577,31 +580,31 @@ VITALICIA_REVERSIVEL_MINIMO_GARANTIDO
           type: array
           items:
             type: string
-            description: Meio(s) de pagamento do Prêmio disponíveis 
+            description: Meio(s) de pagamento do Prêmio disponíveis
             example: CARTAO_CREDITO
-            enum: [CARTAO_CREDITO , DEBITO_CONTA, DEBITO_CONTA_POUPANCA, BOLETO_BANCARIO, PIX, CARTAO_DEBITO, REGRA_PARCEIRO, CONSIGNACAO_FOLHA_PAGAMENTO, PONTOS_PROGRAMAS_BENEFICIO]
+            enum: [ CARTAO_CREDITO , DEBITO_CONTA, DEBITO_CONTA_POUPANCA, BOLETO_BANCARIO, PIX, CARTAO_DEBITO, REGRA_PARCEIRO, CONSIGNACAO_FOLHA_PAGAMENTO, PONTOS_PROGRAMAS_BENEFICIO ]
         frequency:
           type: array
           items:
             type: string
-            description: Periodicidade de pagamento do prêmio 
+            description: Periodicidade de pagamento do prêmio
             example: DIARIA
-            enum: [DIARIA  , MENSAL , UNICA, ANUAL, TRIMESTRAL , SEMESTRAL , FRACIONADO, OUTRA]
+            enum: [ DIARIA  , MENSAL , UNICA, ANUAL, TRIMESTRAL , SEMESTRAL , FRACIONADO, OUTRA ]
         premiumTax:
           type: string
           description: Distribuição de frequência relativa aos valores referentes às taxas cobradas.
     PersonMinimumRequirements:
-        type: object
-        required:
-            - contractingType
-            - contractingMinRequirement
-        properties:
-          contractingType:
-             type: string
-             enum: [COLETIVO, INDIVIDUAL]
-          contractingMinRequirement:
-            type: string
-    LinksPaginated: 
+      type: object
+      required:
+        - contractingType
+        - contractingMinRequirement
+      properties:
+        contractingType:
+          type: string
+          enum: [ COLETIVO, INDIVIDUAL ]
+        contractingMinRequirement:
+          type: string
+    LinksPaginated:
       type: object
       properties:
         self:
@@ -672,13 +675,13 @@ VITALICIA_REVERSIVEL_MINIMO_GARANTIDO
                 description: 'Data e hora da consulta, conforme especificação RFC-3339, formato UTC.'
                 type: string
                 pattern: '[\w\W\s]*'
-                maxLength: 2048  
+                maxLength: 2048
                 format: date-time
                 example: '2021-08-20T08:30:00Z'
             additionalProperties: false
         meta:
           $ref: '#/components/schemas/MetaPaginated'
-      additionalProperties: false    
+      additionalProperties: false
   parameters:
     page:
       name: page
@@ -695,7 +698,7 @@ VITALICIA_REVERSIVEL_MINIMO_GARANTIDO
       schema:
         type: integer
         default: 10
-        minimum: 1  
+        minimum: 1
     cnpjNumber:
       name: cnpjNumber
       in: path
@@ -708,7 +711,7 @@ VITALICIA_REVERSIVEL_MINIMO_GARANTIDO
       in: header
       description: Controle de cache para evitar que informações confidenciais sejam armazenadas em cache.
       required: true
-      schema: 
+      schema:
         type: string
         pattern: '[\w\W\s]*'
     content-Security-Policy:
@@ -731,16 +734,16 @@ VITALICIA_REVERSIVEL_MINIMO_GARANTIDO
       description: Campo para exigir conexões por HTTPS e proteger contra certificados falsificados.
       schema:
         type: string
-        pattern:  '[\w\W\s]*'
+        pattern: '[\w\W\s]*'
     x-Content-Type-Options:
-      name: X-Content-Type-Options
+      name: x-Content-Type-Options
       in: header
       description: Campo para evitar que navegadores executem a detecção de MIME e interpretem respostas como HTML de forma inadequada.
       schema:
         type: string
         pattern: '[\w\W\s]*'
     x-Frame-Options:
-      name: X-Frame-Options
+      name: x-Frame-Options
       in: header
       description: Campo indica se o navegador deve ou não renderizar um frame.
       schema:
@@ -758,7 +761,7 @@ VITALICIA_REVERSIVEL_MINIMO_GARANTIDO
           authorizationUrl: 'https://authserver.example/authorization'
           tokenUrl: 'https://authserver.example/token'
           scopes:
-            financings: Escopo necessário para acesso à API. O controle dos endpoints específicos é feito via permissions.    
+            financings: Escopo necessário para acesso à API. O controle dos endpoints específicos é feito via permissions.
   responses:
 
     BadRequest:
@@ -808,4 +811,4 @@ VITALICIA_REVERSIVEL_MINIMO_GARANTIDO
       content:
         application/json; charset=utf-8:
           schema:
-            $ref: '#/components/schemas/ResponseError'          
+            $ref: '#/components/schemas/ResponseError'

--- a/documentation/source/files/swagger/status_outage.yaml
+++ b/documentation/source/files/swagger/status_outage.yaml
@@ -1,0 +1,208 @@
+openapi: 3.0.0
+info:
+  title: APIs comuns
+  description: As APIs descritas neste documento são referentes as APIs da fase Open Data do Open Insurance Brasil.
+  version: 1.0.0
+  contact:
+    url: https://openinsurance.susep.gov.br
+servers:
+  - url: https://api.organizacao.com.br/open-insurance/discovery/v1
+tags:
+  - name: 'API de status'
+  - name: 'API de outages'
+paths:
+  /status:
+    get:
+      tags:
+        - API de status
+      summary: A descrição referente ao código de status retornado pelas APIs
+      description: ' Descrição referente ao código de status retornado pelas APIs'
+      operationId: 'getStatus'
+      parameters:
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
+      responses:
+        '200':
+          description: Código de status retornado pelas APIs
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseDiscoveryStatusList'
+  /outages:
+    get:
+      tags:
+        - API de outages
+      summary: a descrição referente a listagem de indisponibilidades agendadas para os serviços
+      description: 'a descrição referente a listagem de indisponibilidades agendadas para os serviços'
+      operationId: 'getOutage'
+      parameters:
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/pageSize'
+      responses:
+        '200':
+          description: listagem de indisponibilidades agendadas para os serviços
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ResponseDiscoveryOutageList'
+components:
+  schemas:
+    ResponseDiscoveryStatusList:
+      type: object
+      required:
+        - data
+        - links
+        - meta
+      properties:
+        data:
+          type: object
+          required:
+            - status
+          properties:
+            status:
+              type: array
+              items:
+                $ref: '#/components/schemas/Status'
+        links:
+          $ref: '#/components/schemas/Links'
+        meta:
+          $ref: '#/components/schemas/Meta'
+    ResponseDiscoveryOutageList:
+      type: object
+      required:
+        - data
+        - links
+        - meta
+      properties:
+        data:
+          type: array
+          items:
+            required:
+              - outageTime
+              - duration
+              - isPartial
+              - explanation
+              - unavailableEndpoints
+            properties:
+              outageTime:
+                type: string
+                description: Data e hora planejada do início da indisponibilidade
+                example: '2020-07-21T08:30:00Z'
+              duration:
+                type: string
+                description: Duração prevista da indisponibilidade
+                example: PT2H30M
+              isPartial:
+                type: boolean
+                description: Flag que indica se a indisponibilidade é parcial (atingindo apenas alguns end points) ou total (atingindo todos os end points)
+                example: false
+              explanation:
+                type: string
+                description: Explicação sobre os motivos da indisponibilidade.
+                example: Atualização do API Gateway
+              unavailableEndpoints:
+                type: array
+                description: Endpoints com indisponibilidade.
+                items:
+                  type: string
+                example:
+                  - 'https://api.seguradora.com.br/open-insurance/channels/v1/electronic-channels'
+        links:
+          $ref: '#/components/schemas/Links'
+        meta:
+          $ref: '#/components/schemas/Meta'
+    Links:
+      type: object
+      properties:
+        self:
+          type: string
+          description: URL da página atualmente requisitada
+          example: 'https://api.seguradora.com.br/open-insurance/channels/v1/<resource>'
+        first:
+          type: string
+          description: URL da primeira página de registros
+          example: 'https://api.seguradora.com.br/open-insurance/channels/v1/<resource>'
+        prev:
+          type: string
+          description: URL da página anterior de registros
+        next:
+          type: string
+          description: URL da próxima página de registros
+        last:
+          type: string
+          description: URL da última página de registros
+          example: 'https://api.seguradora.com.br/open-insurance/channels/v1/<resource>'
+    Meta:
+      type: object
+      properties:
+        totalRecords:
+          type: integer
+          description: Total de registros encontrados
+          example: 9
+        totalPages:
+          type: integer
+          description: Total de páginas para os registros encontrados
+          example: 3
+      required:
+        - totalRecords
+        - totalPages
+    Status:
+      type: object
+      required:
+        - code
+        - explanation
+      properties:
+        code:
+          type: string
+          enum:
+            - OK
+            - PARTIAL_FAILURE
+            - UNAVAILABLE
+            - SCHEDULED_OUTAGE
+          description: >
+            Condição atual da API:
+              * `OK` - A implementação é totalmente funcional
+              * `PARTIAL_FAILURE` - Um ou mais endpoints estão indisponíveis
+              * `UNAVAILABLE` - A implementação completa está indisponível
+              * `SCHEDULED_OUTAGE` - Uma interrupção anunciada está em vigor
+          example: OK
+        explanation:
+          type: string
+          description: Fornece uma explicação da interrupção atual que pode ser exibida para um cliente final. Será obrigatoriamente preenchido se code tiver algum valor que não seja OK
+          example: Retorno com Sucesso
+        detectionTime:
+          type: string
+          description: A data e hora em que a interrupção atual foi detectada. Será obrigatoriamente preenchido se a propriedade code for PARTIAL_FAILURE ou UNAVAILABLE
+          example: '2021-07-21T08:30:00Z'
+        expectedResolutionTime:
+          type: string
+          description: A data e hora em que o serviço completo deve continuar (se conhecido). Será obrigatoriamente preenchido se code tiver algum valor que não seja OK
+          example: '2021-07-21T08:30:00Z'
+        updateTime:
+          type: string
+          description: A data e hora em que esse status foi atualizado pela última vez pelo titular dos dados.
+          example: '2021-01-02T01:00:00Z'
+        unavailableEndpoints:
+          type: array
+          description: Endpoints com indisponibilidade
+          items:
+            type: string
+          example:
+            - 'https://api.seguradora.com.br/open-insurance/channels/v1/electronic-channels'
+  parameters:
+    page:
+      name: page
+      in: query
+      description: Número da página que está sendo requisitada, sendo a primeira página 1.
+      schema:
+        type: integer
+        default: 1
+        minimum: 1
+    pageSize:
+      name: page-size
+      in: query
+      description: Quantidade total de registros por páginas.
+      schema:
+        type: integer
+        default: 25
+        minimum: 1


### PR DESCRIPTION
- A estrutura de produtos deveria ser uniforme para todas as apis.

Atualmente o array de produtos usado em cada uma das apis está diferente:
```
auto-insurance         data.brand.company.0.products
capitalization-title   brand.companies.0.product
home-insurance         data.brand.company.products
life-pension           0.products
pension-plan           brand.companies.products
person                 data.brand.companies.0.products
```

* Alguns tem 'brand' dentro de 'data' e outros não.
* Alguns usam o nome 'company' e outros 'companies'
* Em algumas apis a propriedade 'companies'/'company' é um objeto, em outras um array
* life-pension tem como raíz um array, que contem products
* life-pension não tem 'brand' nem 'company' como todos os outros

Conceitualmente, o relacionamento brand/company/product é o mesmo para todo sistema,
qualquer que seja o tipo de produto, portanto todas as apis deveriam seguir o mesmo modelo.

O ideal seria ser assim:
```
auto-insurance         data.brand.companies.0.products
capitalization-title   data.brand.companies.0.products
home-insurance         data.brand.companies.0.products
life-pension           data.brand.companies.0.products
pension-plan           data.brand.companies.0.products
person                 data.brand.companies.0.products
```

Para termos uma comparação, a api de canais é uniforme:
```
branches               data.brand.companies.0.branches
electronic-channels    data.brand.companies.0.electronicChannels
phone-channels         data.brand.companies.0.phoneChannels
```

Neste pull request os arquivo swagger foram ajustados para ficar com essa estrutura.