### PR TITLE
Centraliza blockquotes de segurança

### DIFF
--- a/documentation/source/includes/_security.md.erb
+++ b/documentation/source/includes/_security.md.erb
@@ -128,7 +128,7 @@ Todos os participantes devem ter certeza de que todos os atores do ecossistema e
 
 O ecossistema de compartilhamento de dados definido pelo Brasil consiste em muitos padrões diferentes, todos girando em torno de conceitos, funções e obrigações que foram tecnicamente definidos no [OAuth 2.0 Authorization Framework](https://tools.ietf.org/html/rfc6749).
 
-> A estrutura de autorização OAuth 2.0 permite uma aplicação de terceiros (third-party application) obter acesso limitado a um serviço HTTP, seja em nome do proprietário de recurso (resource owner) por meio da orquestração de uma interação de aprovação entre o proprietário do recurso e o serviço HTTP, ou permitindo a aplicação de terceiros obter acesso em seu próprio nome.
+A estrutura de autorização OAuth 2.0 permite uma aplicação de terceiros (third-party application) obter acesso limitado a um serviço HTTP, seja em nome do proprietário de recurso (resource owner) por meio da orquestração de uma interação de aprovação entre o proprietário do recurso e o serviço HTTP, ou permitindo a aplicação de terceiros obter acesso em seu próprio nome.
 
 A especificação base OAuth 2.0 não fornece, por si só, informações suficientes para atender a todas as necessidades definidas pelo framework de confiança do Open Insurance Brasil. Mais notavelmente, não possui uma maneira de transmitir informações de identidade do cliente em um formato padronizado de uma instituição transmissora para uma receptora, e os mecanismos de autenticação que foram definidos na especificação original não são seguros o suficiente para atender aos requisitos de uma indústria altamente regulamentada.
 
@@ -136,7 +136,7 @@ A especificação base OAuth 2.0 não fornece, por si só, informações suficie
 
 ***Este perfil herda todas as obrigações do OAuth 2.0***
 
-> [OpenID Connect](https://openid.net/connect/) é um conjunto de especificações simplificadas que fornecem uma estrutura para interações de identidade por meio de APIs do tipo REST. A implementação mais simples do OpenID Connect permite que clients de todos os tipos, incluindo baseados em navegador, celulares e clients javascript, solicitem e recebam informações sobre identidades e sessões atualmente autenticadas. O conjunto de especificações é extensível, permitindo que os participantes também suportem, opcionalmente, criptografia de dados de identidade, descoberta do OpenID Provider e gerenciamento avançado de sessão, incluindo logout.
+[OpenID Connect](https://openid.net/connect/) é um conjunto de especificações simplificadas que fornecem uma estrutura para interações de identidade por meio de APIs do tipo REST. A implementação mais simples do OpenID Connect permite que clients de todos os tipos, incluindo baseados em navegador, celulares e clients javascript, solicitem e recebam informações sobre identidades e sessões atualmente autenticadas. O conjunto de especificações é extensível, permitindo que os participantes também suportem, opcionalmente, criptografia de dados de identidade, descoberta do OpenID Provider e gerenciamento avançado de sessão, incluindo logout.
 
 O grupo de trabalho OpenID Foundations Connect tem sido o guardião do Padrão de Identidade “de fato” da Internet por muitos anos, trabalhando em várias especificações que se baseiam no framework de autorização OAuth 2.0, adicionando recursos e requisitos de suporte para melhorar a segurança do framework em si.
 
@@ -144,9 +144,9 @@ O grupo de trabalho OpenID Foundations Connect tem sido o guardião do Padrão d
 
 [Open ID Connect Discovery](https://openid.net/specs/openid-connect-discovery-1_0.html): apresenta o conceito de um documento de descoberta usado por *OpenID Connect (OIDC) Providers* para anunciar como os *clients* OAuth 2.0 podem se comunicar com eles e quais recursos e opções o OIDC Provider oferece suporte.
 
-[RFC7591](https://tools.ietf.org/html/rfc7591): além de definir o processo de registro dinâmico de *clients* OAuth, esta especificação apresenta o conceito de [Software Statement](https://tools.ietf.org/html/rfc7591#section-2.3) (“Declaração de Software”), que pode ser usada para fornecer informações sobre um *client* que é atestado por um serviço de terceiros. Outros atributos de metadados também são definidos no [OpenID Connect Registration Specification](https://openid.net/specs/openid-connect-registration-1_0.html)
+[RFC7591](https://tools.ietf.org/html/rfc7591): além de definir o processo de registro dinâmico de *clients* OAuth, esta especificação apresenta o conceito de [Software Statement](https://tools.ietf.org/html/rfc7591#section-2.3) (“Declaração de Software”), que pode ser usada para fornecer informações sobre um *client* que é atestado por um serviço de terceiros. Outros atributos de metadados também são definidos no [OpenID Connect Registration Specification](https://openid.net/specs/openid-connect-registration-1_0.html):
 
-> Esta especificação define mecanismos para registrar dinamicamente *clients* OAuth 2.0 com *Authorization Servers* (servidores de autorização). Pedidos de registro enviam um conjunto de valores de metadados do *client* desejado para o *Authorization Server*. As respostas de registro resultantes retornam um *client identifier* para ser usado no *Authorization Server* e os valores de metadados registrados para o *client*. O *client* pode então usar esta informação de registro para se comunicar com o *Authorization Server* usando o protocolo OAuth 2.0. Esta especificação também define um conjunto de campos de metadados do *client* e valores para os *clients* usarem durante o registro.
+Esta especificação define mecanismos para registrar dinamicamente *clients* OAuth 2.0 com *Authorization Servers* (servidores de autorização). Pedidos de registro enviam um conjunto de valores de metadados do *client* desejado para o *Authorization Server*. As respostas de registro resultantes retornam um *client identifier* para ser usado no *Authorization Server* e os valores de metadados registrados para o *client*. O *client* pode então usar esta informação de registro para se comunicar com o *Authorization Server* usando o protocolo OAuth 2.0. Esta especificação também define um conjunto de campos de metadados do *client* e valores para os *clients* usarem durante o registro.
 
 [RFC7592](https://tools.ietf.org/html/rfc7592): Esta especificação define métodos de gerenciamento de *dynamic client registration* (registros de cliente dinâmico) do OAuth 2.0 para casos de uso em que as propriedades de um *client* registrado necessitam ser alteradas durante a vida do *client*.
 
@@ -166,7 +166,7 @@ O perfil Baseline foi originalmente planejado para ser mais facilmente implement
 
 O [FAPI 1.0: Advanced profile](https://openid.net/specs/openid-financial-api-part-2-1_0.html) é atual padrão ouro para API Security, fornecendo um framework de especificação que foi usado como ponto de partida para a criação de uma especificação para o Open Insurance Brasil.
 
-> Este padrão especifica um perfil de segurança avançado do OAuth que é adequado para ser usado para proteger APIs com alto risco inerente. Os exemplos incluem APIs que dão acesso a dados altamente confidenciais ou que podem ser usados para acionar transações financeiras (por exemplo, início de pagamento). Este padrão especifica os controles contra ataques, como: violação de solicitação de autorização, violação de resposta de autorização, incluindo injeção de código, injeção de estado e phishing de solicitação de token.
+Este padrão especifica um perfil de segurança avançado do OAuth que é adequado para ser usado para proteger APIs com alto risco inerente. Os exemplos incluem APIs que dão acesso a dados altamente confidenciais ou que podem ser usados para acionar transações financeiras (por exemplo, início de pagamento). Este padrão especifica os controles contra ataques, como: violação de solicitação de autorização, violação de resposta de autorização, incluindo injeção de código, injeção de estado e phishing de solicitação de token.
 
 ![FAPI profile](../images/FAPI.png "FAPI profile")
 
@@ -283,7 +283,7 @@ Um novo aplicativo ou declaração de software pode ser registrado fazendo logon
 ### 1.4.1 Atribuição de Funções Regulatórias de Software
 Em um ecossistema de compartilhamento de dados complexo e diversificado, as funções regulatórias de uma organização podem mudar. Eles podem ser adicionados e revogados. Isso significa que o software adicionado ao Diretório pode receber permissão de ter zero (0) ou mais funções regulatórias. Um administrador pode atribuir a um determinado software todo e qualquer permissões que a organização proprietária do software pode ter.
 
-> Se uma organização perder uma função regulatória, todo software com essa função regulatória será revogado do ecossistema, portanto, é muito importante que um aplicativo receba apenas as funções de que realmente precisa para funcionar.
+Se uma organização perder uma função regulatória, todo software com essa função regulatória será revogado do ecossistema, portanto, é muito importante que um aplicativo receba apenas as funções de que realmente precisa para funcionar.
 
 ### 1.5 Criação e Upload de Certificados
 ### 1.5.1 Sandbox
@@ -312,6 +312,7 @@ Esses JWTs podem ser criptografados também usando o JSON Web Encryption (JWE). 
 
 **Exemplo de Request Object JWT assinado**
 
+<div class="center-column"></div>
 ```
 eyJhbGciOiJQUzI1NiIsInR5cCI6Im9hdXRoLWF1dGh6LXJlcStqd3QiLCJraWQiOiJ4U2tpbXRFa2EyUzFrdDBFQUV4MlJmNkZLendHSi1zUzRReHYzN2xiU2l3In0
 .
@@ -322,6 +323,7 @@ I-75Ev8Swlk3AXEXevFEyV3FVA40VjjIJQu3sImcVGrxdA3qFzw-gxIMCEHamC94TktI_mv6jebwJa_W
 
 O exemplo acima é apresentado decodificado logo abaixo. No cabeçalho está incluso o atributo ‘kid’ (id da chave) com o valor `xSkimtEka2S1kt0EAEx2Rf6FKzwGJ-sS4Qxv37lbSiw`, que pode ser localizado no JSON Web KeySet para este cliente [aqui](https://keystore.sandbox.directory.opinbrasil.com.br/4b75db2e-a0c0-4359-a077-684e88fa695c/cd080791-9f2b-4b0d-b6a4-953be52b5971/application.jwks)
 
+<div class="center-column"></div>
 ```
 {
   "alg": "PS256",
@@ -386,6 +388,7 @@ O exemplo acima é apresentado decodificado logo abaixo. No cabeçalho está inc
 
 O JWK público do JWKS retirado da uri fornecido anteriormente
 
+<div class="center-column"></div>
 ```
 {
   "kty":"RSA",
@@ -401,6 +404,7 @@ O JWK público do JWKS retirado da uri fornecido anteriormente
 
 A chave privada que foi usada para criar o JWS
 
+<div class="center-column"></div>
 ```
 -----BEGIN PRIVATE KEY-----
 MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC8IHx8C4J7Eyis
@@ -451,6 +455,7 @@ Os certificados para acesso às APIs publicadas pelas instituições participant
 
 - Use o OpenID Issuer e a Cláusula 4 da especificação [OpenID Connect Discovery](https://openid.net/specs/openid-connect-discovery-1_0.html) para obter o documento `openid-configuration`.
 
+<div class="center-column"></div>
 ```
 curl https://auth.directory.opinbrasil.com.br/.well-known/openid-configuration
 
@@ -585,6 +590,7 @@ curl https://auth.directory.opinbrasil.com.br/.well-known/openid-configuration
 
 - Obtenha o `alias` do endpoint do Mutual TLS Token, conforme definido por [RFC8705 - OAuth 2.0 Mutual-TLS Client Authentication and Certificate-Bound Access Tokens](https://tools.ietf.org/html/rfc8705)
 
+<div class="center-column"></div>
 ```
  "mtls_endpoint_aliases": {
     "token_endpoint": "https://matls-auth.directory.opinbrasil.com.br/token",
@@ -593,6 +599,7 @@ curl https://auth.directory.opinbrasil.com.br/.well-known/openid-configuration
 
 - Estabeleça uma conexão TLS mútua usando o certificado de transporte registrado anteriormente e solicite um token de acesso com o escopo `directory:software`
 
+<div class="center-column"></div>
 ```
 curl --cert transport.pem --key transport.key https://matls-auth.directory.opinbrasil.com.br/token -X POST -d 'client_id=cd080791-9f2b-4b0d-b6a4-953be52b5971&grant_type=client_credentials&scope=directory:software'
 
@@ -607,6 +614,7 @@ Consulte a especificação do [Diretório OpenAPI v3](https://raw.githubusercont
 ### 2.4 Descobrindo Authorization Servers de Seguradoras
 Faça uma busca pelo recurso de participantes (informações públicas) e obtenha uma lista de todos os participantes e seus Authorization Servers.
 
+<div class="center-column"></div>
 ```
 curl https://data.directory.opinbrasil.com.br/participants
 
@@ -659,6 +667,7 @@ Um SSA não tem período de validade, é simplesmente um registro pontual do que
 
 * Obtenha um token de acesso e, em seguida, carregue a declaração do software para um aplicativo no Diretório.
 
+<div class="center-column"></div>
 ```
 curl --cert transport.pem --key transport.key https://matls-auth.directory.opinbrasil.com.br/token -X POST -d 'client_id=cd080791-9f2b-4b0d-b6a4-953be52b5971&grant_type=client_credentials&scope=directory:software'
 
@@ -695,6 +704,7 @@ Esses exemplos **não normativos** presumem que o cliente OAuth descobriu os loc
 
 1. Obtendo um Token de Acesso com escopo 'consents'
 
+<div class="center-column"></div>
 ```
 curl --cert transport.pem --key transport.key https://matls-auth.amazinginsurance.com.br/token -X POST -d 'client_id=clientIdFromAmazingInsurance&grant_type=client_credentials&scope=consents'
 
@@ -703,6 +713,7 @@ curl --cert transport.pem --key transport.key https://matls-auth.amazinginsuranc
 
 2. Criando um recurso de consentimento
 
+<div class="center-column"></div>
 ```
 curl --cert transport.pem --key transport.key -H 'Authorization: Bearer 2Pjwts8m1KRZmm0aJyXbOTB8zRosN55fo8Ewdulhxxa'
 -H "Content-Type: application/json"
@@ -780,6 +791,7 @@ A tabela abaixo reflete os diferentes profiles de segurança e combinações que
 
 Todos os requisitos para o OpenID Request Object estão incluídos no [Perfil de Segurança do Open Insurance Brasil](https://openbanking-brasil.github.io/specs-seguranca/open-banking-brasil-financial-api-1_ID3-ptbr.html). Veja o exemplo com JWS a seguir:
 
+<div class="center-column"></div>
 ```
 {
  "alg": "PS256",
@@ -832,6 +844,7 @@ Também é opcional para receptoras solicitar `claims` de identidade ('Identity 
 
 Por exemplo:
 
+<div class="center-column"></div>
 ```
 "cpf": {
         "essential": true,
@@ -846,6 +859,8 @@ Solicitar reivindicações de valor específico é totalmente opcional para o re
 ### 4.3.2 Redirecionar o Usuário ao Authorization Server para Autorização
 
 De acordo com o OpenID Connect Core.
+
+<div class="center-column"></div>
 ```
 https://auth.amazinginsurance.com.br/auth?client_id=clientIdFromAmazingInsurance&scope=openid&request=eyJhbGciOiJQUzI1NiIsInR5cCI6Im9hdXRoLWF1dGh6LXJlcStqd3QiLCJraWQiOiJQV0FpNXJ1UWNIZnpQenEySkZkcFk3bkFVaDZMelRUUXRE...j1CpNMT7NtDerEl32E8plGnsuA
 ```
@@ -858,6 +873,7 @@ Conforme [RFC 7636 Proof Key for Code Exchange](https://tools.ietf.org/html/rfc7
 
 Neste ponto, um receptor pode, opcionalmente, verificar o status da solicitação de consentimento para ver se mudou para totalmente autorizado. Esta etapa não deverá ser necessária para recursos que não requerem consentimento de múltiplos indivíduos, entretanto, para contas comerciais ou contas conjuntas com requisitos de acesso especiais, a seguradora pode demorar um pouco para obter as autorizações adicionais necessárias para que esse consentimento seja totalmente autorizado. Os receptores não devem abusar da verificação do status da API de consentimento.
 
+<div class="center-column"></div>
 ```
 curl --cert transport.pem --key transport.key -H 'Authorization: Bearer 2Pjwts8m1KRZmm0aJyXbOTB8zRosN55fo8Ewdulhxxa'
  https://matls-api.amazinginsurance.com.br/consents/v1/consents/urn:amazinginsurance:0be7a3bb-33e6-4d73-b60a-9523aee6cc0d
@@ -1125,6 +1141,7 @@ Uma declaração de software (_software\_statement_) é um [JSON Web Token (JWT)
 
 O exemplo a seguir contém todos os atributos atualmente incluídos em um _software\_statement_:
 
+<div class="center-column"></div>
 ```
 {
   "software_mode": "Live",
@@ -1185,6 +1202,7 @@ O exemplo a seguir contém todos os atributos atualmente incluídos em um _softw
 Este exemplo inclui vários campos opcionais, alguns dos quais podem não ser aplicáveis a algumas implantações. Para um guia completo dos atributos e sua obrigatoriedade, consultar o [Swagger DCR](../files/swagger/dcr-dcm-swagger.yaml).
 A quebra de linha dentro dos valores são apenas para fins de exibição.
 
+<div class="center-column"></div>
 ```
 POST /reg HTTP/1.1
 Host: auth.raidiam.com
@@ -1459,6 +1477,7 @@ Os certificados para Front-End são utilizados para disponibilizar serviços, em
 
 ### Modelo de Configuração de Certificado Cliente - OpenSSL
 
+<div class="center-column"></div>
 ```
 [req]
 default_bits = 2048
@@ -1493,6 +1512,7 @@ DNS = <FQDN|Wildcard>
 
 ### Modelo de Configuração de Certificado de Assinatura - OpenSSL
 
+<div class="center-column"></div>
 ```
 [req]
 default_bits = 2048

--- a/documentation/source/stylesheets/screen.css.scss
+++ b/documentation/source/stylesheets/screen.css.scss
@@ -514,6 +514,18 @@ html, body {
   }
 }
 
+.content {
+  .center-column + .highlight {
+    pre {
+      position: static;
+      float: none;
+      clear: none;
+      margin: 0 28px;
+      left: 0;
+    }
+  }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // CODE SAMPLE STYLES
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Criação da classe center-column*, para mover os blocos de código/JSON da documentação de segurança do painel lateral para o painel central.
Remoção de quotes '>' na documentação de segurança.

*Baseado em https://github.com/slatedocs/slate/issues/855