### PR TITLE
Correção de link de RP e formatação

### DIFF
--- a/documentation/source/includes/_security.md.erb
+++ b/documentation/source/includes/_security.md.erb
@@ -65,15 +65,15 @@ Todos os detalhes para a execução dos testes e obtenção dos certificados pod
 ### Materiais complementares
 
 1. Certificação de segurança, OP
-    1. Documentação: https://openid.net/certification/op_submission
-    2. Termos: https://openid.net/certification/instructions/#:~:text=OpenID%20Certification%20Terms%20and%20Conditions
-    3. Solicitação: https://openid.atlassian.net/servicedesk/customer/portal/3/group/3/create/10016
-    4. Abertura de chamados: https://gitlab.com/openid/conformance-suite/-/issues
+    1. Documentação: [https://openid.net/certification/op_submission](https://openid.net/certification/op_submission)
+    2. Termos: [https://openid.net/certification/instructions/#:~:text=OpenID%20Certification%20Terms%20and%20Conditions](https://openid.net/certification/instructions/#:~:text=OpenID%20Certification%20Terms%20and%20Conditions)
+    3. Solicitação: [https://openid.atlassian.net/servicedesk/customer/portal/3/group/3/create/10016](https://openid.atlassian.net/servicedesk/customer/portal/3/group/3/create/10016)
+    4. Abertura de chamados: [https://gitlab.com/openid/conformance-suite/-/issues](https://gitlab.com/openid/conformance-suite/-/issues)
 2. Certificação de segurança, RP
-    1. Documentação: https://openid.net/certification/rp_submission/
-    2. Termos: https://openid.net/certification/instructions/#:~:text=OpenID%20Certification%20Terms%20and%20Conditions
-    3. Solicitação: https://openid.atlassian.net/servicedesk/customer/portal/3/group/3/create/10016
-    4. Abertura de chamados: https://gitlab.com/openid/conformance-suite/-/issues
+    1. Documentação: [https://openid.net/certification/connect_rp_submission/](https://openid.net/certification/connect_rp_submission/)
+    2. Termos: [https://openid.net/certification/instructions/#:~:text=OpenID%20Certification%20Terms%20and%20Conditions](https://openid.net/certification/instructions/#:~:text=OpenID%20Certification%20Terms%20and%20Conditions)
+    3. Solicitação: [https://openid.atlassian.net/servicedesk/customer/portal/3/group/3/create/10016](https://openid.atlassian.net/servicedesk/customer/portal/3/group/3/create/10016)
+    4. Abertura de chamados: [https://gitlab.com/openid/conformance-suite/-/issues](https://gitlab.com/openid/conformance-suite/-/issues)
 
 ### Workshops
 


### PR DESCRIPTION
Alteração do link de RP que estava descontinuado e correção do markdown para links serem clicáveis na versão publicada do site.