### PR TITLE
Hotfix - Correçãoo campo documentationDeliveryDate

### DIFF
--- a/documentation/source/files/swagger/insurance-acceptance-and-branches-abroad.yaml
+++ b/documentation/source/files/swagger/insurance-acceptance-and-branches-abroad.yaml
@@ -33,7 +33,7 @@ info:
     ### `/{policyId}/claim`
       - permissions:
         - GET: **DAMAGES_AND_PEOPLE_ACCEPTANCE_AND_BRANCHES_ABROAD_CLAIM_READ**
-  version: 1.2.0
+  version: 1.2.1
   contact:
     name: Governança do Open Insurance Brasil
     url: 'https://www.gov.br/susep/'
@@ -987,7 +987,6 @@ components:
       type: object
       required:
         - identification
-        - documentationDeliveryDate
         - status
         - statusAlterationDate
         - occurrenceDate
@@ -999,7 +998,7 @@ components:
           type: string
           maxLength: 50
         documentationDeliveryDate:
-          description: Data de entrega da documentação completa
+          description: Data de entrega da documentação completa (Caso tenha ocorrido toda a entrega)
           type: string
           format: date
           maxLength: 10

--- a/documentation/source/files/swagger/insurance-auto.yaml
+++ b/documentation/source/files/swagger/insurance-auto.yaml
@@ -33,7 +33,7 @@ info:
     ### `/{policyId}/claim`
       - permissions:
         - GET: **DAMAGES_AND_PEOPLE_AUTO_CLAIM_READ**
-  version: 1.2.0
+  version: 1.2.1
   contact:
     name: Governança do Open Insurance Brasil
     url: 'https://www.gov.br/susep/'
@@ -1282,7 +1282,6 @@ components:
       type: object
       required:
         - identification
-        - documentationDeliveryDate
         - status
         - statusAlterationDate
         - occurrenceDate
@@ -1294,7 +1293,7 @@ components:
           type: string
           maxLength: 50
         documentationDeliveryDate:
-          description: Data de entrega da documentação completa
+          description: Data de entrega da documentação completa (Caso tenha ocorrido toda a entrega)
           type: string
           format: date
           maxLength: 10

--- a/documentation/source/files/swagger/insurance-financial-risk.yaml
+++ b/documentation/source/files/swagger/insurance-financial-risk.yaml
@@ -33,7 +33,7 @@ info:
     ### `/{policyId}/claim`
       - permissions:
         - GET: **DAMAGES_AND_PEOPLE_FINANCIAL_RISKS_CLAIM_READ**
-  version: 1.2.0
+  version: 1.2.1
   contact:
     name: Governança do Open Insurance Brasil
     url: 'https://www.gov.br/susep/'
@@ -1023,7 +1023,6 @@ components:
       type: object
       required:
         - identification
-        - documentationDeliveryDate
         - status
         - statusAlterationDate
         - occurrenceDate
@@ -1035,7 +1034,7 @@ components:
           type: string
           maxLength: 50
         documentationDeliveryDate:
-          description: Data de entrega da documentação completa
+          description: Data de entrega da documentação completa (Caso tenha ocorrido toda a entrega)
           type: string
           format: date
           maxLength: 10

--- a/documentation/source/files/swagger/insurance-housing.yaml
+++ b/documentation/source/files/swagger/insurance-housing.yaml
@@ -33,7 +33,7 @@ info:
     ### `/{policyId}/claim`
       - permissions:
         - GET: **DAMAGES_AND_PEOPLE_HOUSING_CLAIM_READ**
-  version: 1.2.0
+  version: 1.2.1
   contact:
     name: Governança do Open Insurance Brasil
     url: 'https://www.gov.br/susep/'
@@ -1015,7 +1015,6 @@ components:
       type: object
       required:
         - identification
-        - documentationDeliveryDate
         - status
         - statusAlterationDate
         - occurrenceDate
@@ -1027,7 +1026,7 @@ components:
           type: string
           maxLength: 50
         documentationDeliveryDate:
-          description: Data de entrega da documentação completa
+          description: Data de entrega da documentação completa (Caso tenha ocorrido toda a entrega)
           type: string
           format: date
           maxLength: 10

--- a/documentation/source/files/swagger/insurance-patrimonial.yaml
+++ b/documentation/source/files/swagger/insurance-patrimonial.yaml
@@ -33,7 +33,7 @@ info:
     ### `/{policyId}/claim`
       - permissions:
         - GET: **DAMAGES_AND_PEOPLE_PATRIMONIAL_CLAIM_READ**
-  version: 1.3.0
+  version: 1.3.1
   contact:
     name: Governança do Open Insurance Brasil
     url: 'https://www.gov.br/susep/'
@@ -981,7 +981,6 @@ components:
       type: object
       required:
         - identification
-        - documentationDeliveryDate
         - status
         - statusAlterationDate
         - occurrenceDate
@@ -993,7 +992,7 @@ components:
           type: string
           maxLength: 50
         documentationDeliveryDate:
-          description: Data de entrega da documentação completa
+          description: Data de entrega da documentação completa (Caso tenha ocorrido toda a entrega)
           type: string
           format: date
           maxLength: 10

--- a/documentation/source/files/swagger/insurance-responsibility.yaml
+++ b/documentation/source/files/swagger/insurance-responsibility.yaml
@@ -33,7 +33,7 @@ info:
     ### `/{policyId}/claim`
       - permissions:
         - GET: **DAMAGES_AND_PEOPLE_RESPONSIBILITY_CLAIM_READ**
-  version: 1.2.0
+  version: 1.2.1
   contact:
     name: Governança do Open Insurance Brasil
     url: 'https://www.gov.br/susep/'
@@ -1110,7 +1110,6 @@ components:
       type: object
       required:
         - identification
-        - documentationDeliveryDate
         - status
         - statusAlterationDate
         - occurrenceDate
@@ -1122,7 +1121,7 @@ components:
           type: string
           maxLength: 50
         documentationDeliveryDate:
-          description: Data de entrega da documentação completa
+          description: Data de entrega da documentação completa (Caso tenha ocorrido toda a entrega)
           type: string
           format: date
           maxLength: 10

--- a/documentation/source/files/swagger/insurance-rural.yaml
+++ b/documentation/source/files/swagger/insurance-rural.yaml
@@ -33,7 +33,7 @@ info:
     ### `/{policyId}/claim`
       - permissions:
         - GET: **DAMAGES_AND_PEOPLE_RURAL_CLAIM_READ**
-  version: 1.2.0
+  version: 1.2.1
   contact:
     name: Governança do Open Insurance Brasil
     url: 'https://www.gov.br/susep/'
@@ -1086,7 +1086,6 @@ components:
       type: object
       required:
         - identification
-        - documentationDeliveryDate
         - status
         - statusAlterationDate
         - occurrenceDate
@@ -1098,7 +1097,7 @@ components:
           type: string
           maxLength: 50
         documentationDeliveryDate:
-          description: Data de entrega da documentação completa
+          description: Data de entrega da documentação completa (Caso tenha ocorrido toda a entrega)
           type: string
           format: date
           maxLength: 10

--- a/documentation/source/files/swagger/insurance-transport.yaml
+++ b/documentation/source/files/swagger/insurance-transport.yaml
@@ -33,7 +33,7 @@ info:
     ### `/{policyId}/claim`
       - permissions:
         - GET: **DAMAGES_AND_PEOPLE_TRANSPORT_CLAIM_READ**
-  version: 1.1.0
+  version: 1.1.1
   contact:
     name: Governança do Open Insurance Brasil
     url: 'https://www.gov.br/susep/'
@@ -1074,7 +1074,6 @@ components:
       type: object
       required:
         - identification
-        - documentationDeliveryDate
         - status
         - statusAlterationDate
         - occurrenceDate
@@ -1086,7 +1085,7 @@ components:
           type: string
           maxLength: 50
         documentationDeliveryDate:
-          description: Data de entrega da documentação completa
+          description: Data de entrega da documentação completa (Caso tenha ocorrido toda a entrega)
           type: string
           format: date
           maxLength: 10


### PR DESCRIPTION
Remoção de obrigatoriedade e correção de descrição do campo "documentationDeliveryDate" em APIs de fase 2 para alinhamento ao manual de Escopo de Dados.